### PR TITLE
Rename Effect type parameter E to R in anchor core

### DIFF
--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
@@ -68,12 +68,12 @@ public fun interface SignalProvider {
 /**
  * A read-only view of an Anchor's state and signals.
  *
- * @param E The [Effect] type.
+ * @param R The [Effect] type.
  * @param S The [ViewState] type.
  */
-public abstract class AnchorSink<E, S> : Anchor<E, S>()
+public abstract class AnchorSink<R, S> : Anchor<R, S>()
   where
-        E : Effect,
+        R : Effect,
         S : ViewState {
   /**
    * The current state as a [StateFlow].
@@ -92,18 +92,18 @@ public abstract class AnchorSink<E, S> : Anchor<E, S>()
  * An Anchor manages the state of a component and handles side effects.
  * It combines state management, effect execution, cancellation, and event/signal emission.
  *
- * @param E The [Effect] type providing dependencies for side effects.
+ * @param R The [Effect] type providing dependencies for side effects.
  * @param S The [ViewState] type representing the UI state.
  */
 @AnchorDsl
-public abstract class Anchor<E, S> :
+public abstract class Anchor<R, S> :
   MutableStateAnchor<S>,
-  EffectAnchor<E>,
-  CancellableAnchor<E, S>,
+  EffectAnchor<R>,
+  CancellableAnchor<R, S>,
   SubscriptionAnchor,
   SignalAnchor
   where
-        E : Effect,
+        R : Effect,
         S : ViewState
 
 /**
@@ -126,9 +126,9 @@ public interface StateAnchor<S> where S : ViewState {
    * @return The result of the block.
    */
   @AnchorDsl
-  public fun <R> withState(
-    block: S.() -> R,
-  ): R =
+  public fun <T> withState(
+    block: S.() -> T,
+  ): T =
     state.run(block)
 }
 
@@ -158,15 +158,15 @@ public interface MutableStateAnchor<S> : StateAnchor<S> where S : ViewState {
 /**
  * Provides the ability to execute side effects.
  *
- * @param E The [Effect] type.
+ * @param R The [Effect] type.
  */
 @AnchorDsl
-public interface EffectAnchor<E> where E : Effect {
+public interface EffectAnchor<R> where R : Effect {
   /**
    * Executes a side effect block using the provided effect dependencies.
    *
    * @param coroutineContext The [CoroutineContext] to run the block in. Defaults to [Dispatchers.IO].
-   * @param block The block to execute with [E] as a receiver.
+   * @param block The block to execute with [R] as a receiver.
    * @return The result of the side effect.
    *
    * Example:
@@ -175,20 +175,20 @@ public interface EffectAnchor<E> where E : Effect {
    * ```
    */
   @AnchorDsl
-  public suspend fun <R> effect(
+  public suspend fun <T> effect(
     coroutineContext: CoroutineContext = Dispatchers.IO,
-    block: suspend E.() -> R,
-  ): R
+    block: suspend R.() -> T,
+  ): T
 }
 
 /**
  * Provides the ability to manage cancellable jobs.
  *
- * @param E The [Effect] type.
+ * @param R The [Effect] type.
  * @param S The [ViewState] type.
  */
 @AnchorDsl
-public interface CancellableAnchor<E, S> where E : Effect, S : ViewState {
+public interface CancellableAnchor<R, S> where R : Effect, S : ViewState {
   /**
    * Executes a block that can be cancelled by its [key].
    *
@@ -208,7 +208,7 @@ public interface CancellableAnchor<E, S> where E : Effect, S : ViewState {
   @AnchorDsl
   public suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<E, S>.() -> Unit,
+    block: suspend Anchor<R, S>.() -> Unit,
   )
 }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorScope.kt
@@ -18,13 +18,13 @@ import dev.kioba.anchor.internal.execute
  * }
  * ```
  *
- * @param E The Effect type providing dependencies for side effects
+ * @param R The Effect type providing dependencies for side effects
  * @param S The ViewState type representing the UI state
  *
  * @see dev.kioba.anchor.compose.anchor For the primary way to execute actions
  * @see dev.kioba.anchor.compose.RememberAnchor For setting up the Anchor scope
  */
-public fun interface AnchorScope<out E : Effect, out S : ViewState> {
+public fun interface AnchorScope<out R : Effect, out S : ViewState> {
   /**
    * Executes an action on the underlying Anchor instance.
    *
@@ -34,7 +34,7 @@ public fun interface AnchorScope<out E : Effect, out S : ViewState> {
    * @param block The action to execute with the Anchor as receiver
    */
   public fun execute(
-    block: suspend Anchor<@UnsafeVariance E, @UnsafeVariance S>.() -> Unit,
+    block: suspend Anchor<@UnsafeVariance R, @UnsafeVariance S>.() -> Unit,
   )
 }
 
@@ -45,18 +45,18 @@ public fun interface AnchorScope<out E : Effect, out S : ViewState> {
  * delegates to the provided ContainedScope. This is used internally by RememberAnchor
  * to provide safe action execution.
  *
- * @param E The Effect type
+ * @param R The Effect type
  * @param S The ViewState type
  * @param containedScope The contained scope to delegate to
  * @return An AnchorScope that delegates execution to the contained scope
  */
 @PublishedApi
-internal fun <E : Effect, S : ViewState> AnchorScope(
-  containedScope: ContainedScope<out Anchor<E, S>, E, S>,
-): AnchorScope<E, S> =
+internal fun <R : Effect, S : ViewState> AnchorScope(
+  containedScope: ContainedScope<out Anchor<R, S>, R, S>,
+): AnchorScope<R, S> =
   AnchorScope { block ->
-    // Safe cast: block with receiver Anchor<E, S> can be called on any Anchor<*, *>
-    // because Anchor<E, S> is a subtype of Anchor<*, *>
+    // Safe cast: block with receiver Anchor<R, S> can be called on any Anchor<*, *>
+    // because Anchor<R, S> is a subtype of Anchor<*, *>
     @Suppress("UNCHECKED_CAST")
     containedScope.execute(block as suspend Anchor<*, *>.() -> Unit)
   }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/RememberAnchorScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/RememberAnchorScope.kt
@@ -11,7 +11,7 @@ public interface RememberAnchorScope {
   /**
    * Creates a new [Anchor] instance.
    *
-   * @param E The [Effect] type.
+   * @param R The [Effect] type.
    * @param S The [ViewState] type.
    * @param effectScope A factory function for the [Effect] dependencies.
    * @param initialState A factory function for the initial [ViewState].
@@ -30,24 +30,24 @@ public interface RememberAnchorScope {
    *   )
    * ```
    */
-  public fun <E, S> create(
-    effectScope: () -> E,
+  public fun <R, S> create(
+    effectScope: () -> R,
     initialState: () -> S,
-    init: (suspend Anchor<E, S>.() -> Unit)? = null,
-    subscriptions: (suspend SubscriptionsScope<E, S>.() -> Unit)? = null,
-  ): Anchor<E, S> where E : Effect, S : ViewState
+    init: (suspend Anchor<R, S>.() -> Unit)? = null,
+    subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)? = null,
+  ): Anchor<R, S> where R : Effect, S : ViewState
 }
 
 /**
  * Default implementation of [RememberAnchorScope] that uses [AnchorRuntime].
  */
 public object AnchorRuntimeScope : RememberAnchorScope {
-  override fun <E : Effect, S : ViewState> create(
-    effectScope: () -> E,
+  override fun <R : Effect, S : ViewState> create(
+    effectScope: () -> R,
     initialState: () -> S,
-    init: (suspend Anchor<E, S>.() -> Unit)?,
-    subscriptions: (suspend SubscriptionsScope<E, S>.() -> Unit)?,
-  ): Anchor<E, S> =
+    init: (suspend Anchor<R, S>.() -> Unit)?,
+    subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)?,
+  ): Anchor<R, S> =
     AnchorRuntime(
       initialState = initialState,
       effectScope = effectScope,

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
@@ -9,22 +9,22 @@ import kotlinx.coroutines.flow.onEach
  *
  * This scope provides a DSL for listening to [Event]s and reacting to them by executing actions on the [Anchor].
  *
- * @param E The [Effect] type.
+ * @param R The [Effect] type.
  * @param S The [ViewState] type.
  */
 @AnchorDsl
-public class SubscriptionsScope<E, S>(
+public class SubscriptionsScope<R, S>(
   @PublishedApi
   internal val chain: Flow<Event>,
   @PublishedApi
-  internal val anchor: Anchor<E, S>,
+  internal val anchor: Anchor<R, S>,
   /**
    * The [Effect] dependencies available in this scope.
    */
-  public val effect: E,
+  public val effect: R,
   @PublishedApi
   internal val flows: MutableList<Flow<*>> = mutableListOf(),
-) where E : Effect, S : ViewState {
+) where R : Effect, S : ViewState {
 
   /**
    * Extension function to execute an action on the [Anchor] for each value emitted by a [Flow].
@@ -35,7 +35,7 @@ public class SubscriptionsScope<E, S>(
    */
   @AnchorDsl
   public fun <I> Flow<I>.anchor(
-    effect: Anchor<E, S>.(I) -> Unit,
+    effect: Anchor<R, S>.(I) -> Unit,
   ): Flow<I> =
     onEach { value -> anchor.effect(value) }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
@@ -33,14 +33,14 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi
-internal class AnchorRuntime<E, S>(
+internal class AnchorRuntime<R, S>(
   val initialState: () -> S,
-  val effectScope: () -> E,
-  internal val init: (suspend Anchor<E, S>.() -> Unit)? = null,
-  internal val subscriptions: (suspend SubscriptionsScope<E, S>.() -> Unit)? = null,
-) : AnchorSink<E, S>()
+  val effectScope: () -> R,
+  internal val init: (suspend Anchor<R, S>.() -> Unit)? = null,
+  internal val subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)? = null,
+) : AnchorSink<R, S>()
   where
-        E : Effect,
+        R : Effect,
         S : ViewState {
   @PublishedApi
   @Suppress("ktlint:standard:backing-property-naming", "PropertyName")
@@ -104,10 +104,10 @@ internal class AnchorRuntime<E, S>(
   ): Unit =
     _viewState.update(reducer)
 
-  override suspend fun <R> effect(
+  override suspend fun <T> effect(
     coroutineContext: CoroutineContext,
-    block: suspend E.() -> R,
-  ): R =
+    block: suspend R.() -> T,
+  ): T =
     withContext(coroutineContext) {
       effect.block()
     }
@@ -134,7 +134,7 @@ internal class AnchorRuntime<E, S>(
    */
   override suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<E, S>.() -> Unit,
+    block: suspend Anchor<R, S>.() -> Unit,
   ) {
     coroutineScope {
       val jobToWait =

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ContainedScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ContainedScope.kt
@@ -8,18 +8,18 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @PublishedApi
-internal interface ContainedScope<R, E, S>
+internal interface ContainedScope<A, R, S>
   where
-R : Anchor<E, S>,
-E : Effect,
+A : Anchor<R, S>,
+R : Effect,
 S : ViewState {
-  val anchor: R
+  val anchor: A
   val coroutineScope: CoroutineScope
 }
 
 @PublishedApi
-internal fun <R, E, S> ContainedScope<R, E, S>.execute(
+internal fun <A, R, S> ContainedScope<A, R, S>.execute(
   block: suspend Anchor<*, *>.() -> Unit,
-) where R : Anchor<E, S>, E : Effect, S : ViewState {
+) where A : Anchor<R, S>, R : Effect, S : ViewState {
   coroutineScope.launch(Dispatchers.Default) { anchor.block() }
 }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
@@ -13,12 +13,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-public class ContainerViewModel<E, S> @PublishedApi internal constructor(
-  internal val anchor: AnchorRuntime<E, S>,
+public class ContainerViewModel<R, S> @PublishedApi internal constructor(
+  internal val anchor: AnchorRuntime<R, S>,
 ) : ViewModel(),
-  AnchorScope<E, S>
+  AnchorScope<R, S>
   where
-        E : Effect,
+        R : Effect,
         S : ViewState {
 
   public val viewState: StateFlow<S>
@@ -27,7 +27,7 @@ public class ContainerViewModel<E, S> @PublishedApi internal constructor(
   public val signals: Flow<SignalProvider>
     get() = anchor.signals
 
-  override fun execute(block: suspend Anchor<E, S>.() -> Unit) {
+  override fun execute(block: suspend Anchor<R, S>.() -> Unit) {
     viewModelScope.launch(Dispatchers.Default) {
       @Suppress("UNCHECKED_CAST")
       anchor.block()

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ViewModelProvider.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ViewModelProvider.kt
@@ -8,12 +8,12 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.internal.AnchorRuntime
 
 @PublishedApi
-internal fun <E, R, S> containerViewModelFactory(
-  factory: () -> R
-): ContainerViewModelFactory where E : Effect, R : AnchorRuntime<E, S>, S : ViewState =
+internal fun <R, A, S> containerViewModelFactory(
+  factory: () -> A
+): ContainerViewModelFactory where R : Effect, A : AnchorRuntime<R, S>, S : ViewState =
   ContainerViewModelFactory { ContainerViewModel(factory()) }
 
-public fun <E : Effect, S : ViewState> anchorContainerViewModelFactory(
-  scope: RememberAnchorScope.() -> Anchor<E, S>,
+public fun <R : Effect, S : ViewState> anchorContainerViewModelFactory(
+  scope: RememberAnchorScope.() -> Anchor<R, S>,
 ): ContainerViewModelFactory =
-  containerViewModelFactory { AnchorRuntimeScope.scope() as AnchorRuntime<E, S> }
+  containerViewModelFactory { AnchorRuntimeScope.scope() as AnchorRuntime<R, S> }


### PR DESCRIPTION
## Summary

- Renames the Effect type parameter from `E` to `R` across the anchor core module, aligning with ZIO convention (`R` = environment/requirements)
- Resolves naming collisions: `ContainedScope` and `ViewModelProvider` receiver params `R` → `A`, method-level `<R>` → `<T>` on `effect()`/`withState()` to avoid shadowing
- Pure mechanical rename — zero logic changes, identical line count (73 insertions, 73 deletions)

This is the first step toward adding an `Err` type parameter for structured error handling (#163).

## Test plan

- [x] `./gradlew :anchor:build` passes
- [x] `./gradlew allTests` passes (137 tasks, all green)
- [x] No logic changes — diff is symmetric (insertions == deletions)

Resolves #159