### PR TITLE
♻️ Rename Effect type parameter E to R in test, compose modules

### DIFF
--- a/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt
+++ b/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt
@@ -114,7 +114,7 @@ public fun <S : ViewState> PreviewAnchor(
  * ViewModel integration, ensuring your state persists throughout the component lifecycle.
  *
  * @param S The [ViewState] type representing your UI state.
- * @param E The [Effect] type providing dependencies for side effects.
+ * @param R The [Effect] type providing dependencies for side effects.
  * @param scope Factory function that creates the [Anchor] instance. Called only once per ViewModel.
  * @param customKey Optional key for ViewModel storage. Defaults to the qualified name of [S].
  *        Use this when you need multiple instances of the same state type in the same scope.
@@ -147,14 +147,14 @@ public fun <S : ViewState> PreviewAnchor(
  */
 @Suppress("ModifierRequired")
 @Composable
-public inline fun <reified S, E> RememberAnchor(
-  noinline scope: @DisallowComposableCalls RememberAnchorScope.() -> Anchor<E, S>,
+public inline fun <reified S, R> RememberAnchor(
+  noinline scope: @DisallowComposableCalls RememberAnchorScope.() -> Anchor<R, S>,
   customKey: String? = null,
   crossinline content: @Composable AnchorStateScope<S>.() -> Unit,
-) where E : Effect, S : ViewState {
+) where R : Effect, S : ViewState {
   val key = customKey ?: S::class.qualifiedName.orEmpty()
 
-  val anchorScope: ContainerViewModel<E, S> =
+  val anchorScope: ContainerViewModel<R, S> =
     viewModel(
       key = key,
       factory = anchorContainerViewModelFactory { scope() },

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
 @AnchorTestDsl
-public inline fun <reified E, reified S> runAnchorTest(
-  noinline builder: RememberAnchorScope.() -> Anchor<E, S>,
-  crossinline block: suspend AnchorTestScope<E, S>.() -> Unit,
-): TestResult where E : Effect, S : ViewState =
+public inline fun <reified R, reified S> runAnchorTest(
+  noinline builder: RememberAnchorScope.() -> Anchor<R, S>,
+  crossinline block: suspend AnchorTestScope<R, S>.() -> Unit,
+): TestResult where R : Effect, S : ViewState =
   runTest {
     AnchorTestScope(builder)
       .apply { block() }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -10,12 +10,12 @@ import dev.kioba.anchor.ViewState
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi
-internal class AnchorTestRuntime<E, S>(
+internal class AnchorTestRuntime<R, S>(
   @PublishedApi
-  internal val effectScope: E,
+  internal val effectScope: R,
   @PublishedApi
   internal val initState: S,
-) : Anchor<E, S>() where E : Effect, S : ViewState {
+) : Anchor<R, S>() where R : Effect, S : ViewState {
 
   val verifyActions = mutableListOf<VerifyAction>()
   private var currentState = initState
@@ -37,15 +37,15 @@ internal class AnchorTestRuntime<E, S>(
 
   override suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<E, S>.() -> Unit,
+    block: suspend Anchor<R, S>.() -> Unit,
   ) {
     block()
   }
 
-  override suspend fun <R> effect(
+  override suspend fun <T> effect(
     coroutineContext: CoroutineContext,
-    block: suspend E.() -> R,
-  ): R =
+    block: suspend R.() -> T,
+  ): T =
     block(effectScope)
 
   override fun reduce(

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -9,30 +9,30 @@ import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-public class AnchorTestScope<E : Effect, S : ViewState>(
+public class AnchorTestScope<R : Effect, S : ViewState>(
   @PublishedApi
-  internal val anchorFactory: RememberAnchorScope.() -> Anchor<E, S>,
+  internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S>,
 ) {
   @PublishedApi
-  internal val givenScope: GivenScopeImpl<E, S> = GivenScopeImpl()
+  internal val givenScope: GivenScopeImpl<R, S> = GivenScopeImpl()
 
   @PublishedApi
-  internal val verifyScope: VerifyScopeImpl<E, S> = VerifyScopeImpl()
+  internal val verifyScope: VerifyScopeImpl<R, S> = VerifyScopeImpl()
 
   @PublishedApi
-  internal lateinit var action: suspend Anchor<E, S>.() -> Unit
+  internal lateinit var action: suspend Anchor<R, S>.() -> Unit
 
   @AnchorTestDsl
   public inline fun given(
     @Suppress("UNUSED_PARAMETER") description: String,
-    block: GivenScope<E, S>.() -> Unit,
+    block: GivenScope<R, S>.() -> Unit,
   ): Unit =
     givenScope.block()
 
   @AnchorTestDsl
   public fun on(
     @Suppress("UNUSED_PARAMETER") description: String,
-    anchorOf: suspend Anchor<E, S>.() -> Unit,
+    anchorOf: suspend Anchor<R, S>.() -> Unit,
   ) {
     action = anchorOf
   }
@@ -40,39 +40,39 @@ public class AnchorTestScope<E : Effect, S : ViewState>(
   @AnchorTestDsl
   public inline fun verify(
     @Suppress("UNUSED_PARAMETER") description: String,
-    block: VerifyScope<E, S>.() -> Unit,
+    block: VerifyScope<R, S>.() -> Unit,
   ) {
     verifyScope.block()
   }
 }
 
 @PublishedApi
-internal suspend inline fun <reified E : Effect, reified S : ViewState> AnchorTestScope<E, S>.assert() {
+internal suspend inline fun <reified R : Effect, reified S : ViewState> AnchorTestScope<R, S>.assert() {
   val rememberAnchorScope = object : RememberAnchorScope {
     @Suppress("UNCHECKED_CAST")
-    override fun <E : Effect, S : ViewState> create(
-      effectScope: () -> E,
+    override fun <R : Effect, S : ViewState> create(
+      effectScope: () -> R,
       initialState: () -> S,
-      init: (suspend Anchor<E, S>.() -> Unit)?,
-      subscriptions: (suspend SubscriptionsScope<E, S>.() -> Unit)?
-    ): Anchor<E, S> =
+      init: (suspend Anchor<R, S>.() -> Unit)?,
+      subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)?
+    ): Anchor<R, S> =
       AnchorTestRuntime(
-        givenScope.effectScope as? E ?: effectScope(),
+        givenScope.effectScope as? R ?: effectScope(),
         givenScope.initState as? S ?: initialState(),
       )
   }
-  val anchor: AnchorTestRuntime<E, S> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<E, S>
+  val anchor: AnchorTestRuntime<R, S> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S>
 
   anchor.action()
 
-  assertEvents<E, S>(anchor.verifyActions, anchor.initState, anchor.effectScope)
+  assertEvents<R, S>(anchor.verifyActions, anchor.initState, anchor.effectScope)
 }
 
 @PublishedApi
-internal inline fun <reified E : Effect, reified S : ViewState> AnchorTestScope<E, S>.assertEvents(
+internal inline fun <reified R : Effect, reified S : ViewState> AnchorTestScope<R, S>.assertEvents(
   actualActions: MutableList<VerifyAction>,
   initialState: S,
-  effectScope: E,
+  effectScope: R,
 ) {
   assertEquals(verifyScope.expectedActions.size, actualActions.size)
 
@@ -81,7 +81,7 @@ internal inline fun <reified E : Effect, reified S : ViewState> AnchorTestScope<
       when (action) {
         is EffectAction<*> -> {
           @Suppress("UNCHECKED_CAST")
-          (action as EffectAction<E>).effect(effectScope)
+          (action as EffectAction<R>).effect(effectScope)
           currentState
         }
 

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
@@ -5,7 +5,7 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
-public interface GivenScope<E : Effect, S : ViewState> {
+public interface GivenScope<R : Effect, S : ViewState> {
   @AnchorTestDsl
   public fun initialState(
     f: () -> S,
@@ -13,11 +13,11 @@ public interface GivenScope<E : Effect, S : ViewState> {
 
   @AnchorTestDsl
   public suspend fun effect(
-    f: E.() -> Unit,
+    f: R.() -> Unit,
   )
 
   @AnchorTestDsl
   public suspend fun effectScope(
-    f: () -> E,
+    f: () -> R,
   )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
@@ -5,15 +5,15 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @PublishedApi
-internal class GivenScopeImpl<E, S> : GivenScope<E, S> where E : Effect, S : ViewState {
+internal class GivenScopeImpl<R, S> : GivenScope<R, S> where R : Effect, S : ViewState {
   @PublishedApi
   internal var initState: S? = null
 
   @PublishedApi
-  internal var effectScope: E? = null
+  internal var effectScope: R? = null
 
   @PublishedApi
-  internal val effects: MutableList<(E.() -> Unit)> = mutableListOf()
+  internal val effects: MutableList<(R.() -> Unit)> = mutableListOf()
 
   @AnchorTestDsl
   override fun initialState(
@@ -24,13 +24,13 @@ internal class GivenScopeImpl<E, S> : GivenScope<E, S> where E : Effect, S : Vie
 
   @AnchorTestDsl
   override suspend fun effect(
-    f: E.() -> Unit,
+    f: R.() -> Unit,
   ) {
     effects.add(f)
   }
 
   override suspend fun effectScope(
-    f: () -> E,
+    f: () -> R,
   ) {
     effectScope = f()
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -7,7 +7,7 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
-public interface VerifyScope<E, S> where E : Effect, S : ViewState {
+public interface VerifyScope<R, S> where R : Effect, S : ViewState {
   @AnchorTestDsl
   public fun assertState(
     f: S.() -> S,
@@ -25,6 +25,6 @@ public interface VerifyScope<E, S> where E : Effect, S : ViewState {
 
   @AnchorTestDsl
   public fun assertEffect(
-    f: E.() -> Unit,
+    f: R.() -> Unit,
   )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -6,10 +6,10 @@ import dev.kioba.anchor.Signal
 import dev.kioba.anchor.ViewState
 
 @PublishedApi
-internal class VerifyScopeImpl<E, S>(
+internal class VerifyScopeImpl<R, S>(
   @PublishedApi
   internal val expectedActions: MutableList<VerifyAction> = mutableListOf(),
-) : VerifyScope<E, S> where E : Effect, S : ViewState {
+) : VerifyScope<R, S> where R : Effect, S : ViewState {
   override fun assertState(
     f: S.() -> S,
   ) {
@@ -29,7 +29,7 @@ internal class VerifyScopeImpl<E, S>(
   }
 
   override fun assertEffect(
-    f: E.() -> Unit,
+    f: R.() -> Unit,
   ) {
     expectedActions.add(EffectAction(f))
   }
@@ -54,6 +54,6 @@ internal data class EventAction(
 ) : VerifyAction
 
 @PublishedApi
-internal data class EffectAction<E>(
-  val effect: E.() -> Unit,
+internal data class EffectAction<R>(
+  val effect: R.() -> Unit,
 ) : VerifyAction


### PR DESCRIPTION
## Summary

- Renames the `E : Effect` type parameter to `R : Effect` across `anchor-test` (7 files) and `anchor-compose` (1 file) to match the core module convention from #170
- Renames method-level `<R>` to `<T>` in `AnchorTestRuntime.effect()` to avoid collision with the class-level `R` (matching `Anchor.kt` and `AnchorRuntime.kt`)
- Pure mechanical rename — no logic changes

Closes #160

## Test plan

- [x] `./gradlew :anchor-test:build` passes
- [x] `./gradlew :anchor-compose:build` passes
- [x] `./gradlew allTests` passes (all platforms including feature module tests)