### PR TITLE
💚 Fix Gradle warnings and add version auto-increment to CI

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -83,6 +83,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          gh release create "$VERSION" --generate-notes --title "v$VERSION"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists — skipping tag and release"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            gh release create "$VERSION" --generate-notes --title "v$VERSION"
+          fi
+
+      - name: Bump patch version
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          NEXT_VERSION="$major.$minor.$((patch + 1))"
+          BRANCH="bump-version-to-$NEXT_VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          sed -i '' "s/^POM_VERSION=.*/POM_VERSION=$NEXT_VERSION/" gradle.properties
+          git add gradle.properties
+          git commit -m "🔖 Bump version to $NEXT_VERSION"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "🔖 Bump version to $NEXT_VERSION" \
+            --body "Automated version bump after publishing v$VERSION." \
+            --base master \
+            --head "$BRANCH"

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,4 +30,4 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: run tests
-        run: ./gradlew check --no-daemon --info
+        run: ./gradlew check --no-daemon

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: run tests
         run: ./gradlew check --no-daemon

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -30,4 +30,4 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: run tests
-        run: ./gradlew check --no-daemon
+        run: ./gradlew check --no-daemon --info

--- a/anchor-compose/build.gradle.kts
+++ b/anchor-compose/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
 
   jvm("desktop")
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.compose"
 
     compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/anchor-test/build.gradle.kts
+++ b/anchor-test/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
   jvm("desktop")
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.test"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()

--- a/anchor/build.gradle.kts
+++ b/anchor/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
 
   jvm("desktop")
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor"
 
     compileSdk = libs.versions.android.compileSdk.get().toInt()

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -38,11 +38,11 @@ android {
   sourceSets {
     getByName("main") {
       manifest.srcFile("src/androidMain/AndroidManifest.xml")
-      java.srcDirs("src/androidMain/kotlin")
-      res.srcDirs("src/androidMain/res")
+      java.directories.add("src/androidMain/kotlin")
+      res.directories.add("src/androidMain/res")
     }
     getByName("androidTest") {
-      java.srcDirs("src/androidInstrumentedTest/kotlin")
+      java.directories.add("src/androidInstrumentedTest/kotlin")
     }
   }
 }

--- a/features/config/build.gradle.kts
+++ b/features/config/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 kotlin {
   explicitApi()
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.features.config"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()
@@ -32,6 +32,7 @@ kotlin {
   ).forEach {
     it.binaries.framework {
       isStatic = true
+      binaryOption("bundleId", "dev.kioba.anchor.features.config")
     }
   }
 

--- a/features/counter/build.gradle.kts
+++ b/features/counter/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
   explicitApi()
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.features.counter"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()
@@ -34,6 +34,7 @@ kotlin {
   ).forEach {
     it.binaries.framework {
       isStatic = true
+      binaryOption("bundleId", "dev.kioba.anchor.features.counter")
     }
   }
 

--- a/features/main/build.gradle.kts
+++ b/features/main/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
   explicitApi()
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.features.main"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()
@@ -33,6 +33,7 @@ kotlin {
   ).forEach {
     it.binaries.framework {
       isStatic = true
+      binaryOption("bundleId", "dev.kioba.anchor.features.main")
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 
 POM_GROUP_ID=dev.kioba.anchor
-POM_VERSION=0.0.10
+POM_VERSION=0.1.0
 mavenCentralHost=CENTRAL_PORTAL

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,9 +9,9 @@ pluginManagement {
   includeBuild("convention-plugins")
   repositories {
     google()
-    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     mavenCentral()
     gradlePluginPortal()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
   }
 }
 

--- a/umbrella/build.gradle.kts
+++ b/umbrella/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 kotlin {
   explicitApi()
 
-  androidLibrary {
+  android {
     namespace = "dev.kioba.anchor.umbrella"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()


### PR DESCRIPTION
## Summary

- Adds missing `bundleId` to feature module iOS frameworks (counter, main, config)
- Renames deprecated `androidLibrary` → `android` in all 7 KMP modules
- Replaces deprecated `srcDirs()` → `directories.add()` in androidApp
- Makes tag creation resilient (skips if tag already exists)
- Adds automatic version bump PR after successful publish
- Bumps version to `0.1.0`

## Test plan

- [x] `./gradlew clean build --warning-mode all` — no `Cannot infer`, `androidLibrary`, or `srcDirs` warnings
- [x] `./gradlew allTests` — all tests pass