### PR TITLE
📝 Add module docs, LLM-friendly documentation, version sync automation

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -109,7 +109,11 @@ jobs:
           sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" README.md
           sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${VERSION}\"|" mkdocs.yml
           sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${VERSION}\`|g" CLAUDE.md
-          git add gradle.properties README.md mkdocs.yml CLAUDE.md
+          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" docs/llms-full.txt
+          sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" docs/llms-full.txt
+          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" AGENTS.md
+          sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" AGENTS.md
+          git add gradle.properties README.md mkdocs.yml CLAUDE.md AGENTS.md docs/llms-full.txt
           git commit -m "🔖 Bump version to $NEXT_VERSION"
           git push origin "$BRANCH"
           gh pr create \

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -105,7 +105,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           sed -i '' "s/^POM_VERSION=.*/POM_VERSION=$NEXT_VERSION/" gradle.properties
-          git add gradle.properties
+          GROUP_ID=$(grep '^POM_GROUP_ID=' gradle.properties | cut -d'=' -f2)
+          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${NEXT_VERSION}|g" README.md
+          sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${NEXT_VERSION}\"|" mkdocs.yml
+          sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${NEXT_VERSION}\`|g" CLAUDE.md
+          git add gradle.properties README.md mkdocs.yml CLAUDE.md
           git commit -m "🔖 Bump version to $NEXT_VERSION"
           git push origin "$BRANCH"
           gh pr create \

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -106,9 +106,9 @@ jobs:
           git checkout -b "$BRANCH"
           sed -i '' "s/^POM_VERSION=.*/POM_VERSION=$NEXT_VERSION/" gradle.properties
           GROUP_ID=$(grep '^POM_GROUP_ID=' gradle.properties | cut -d'=' -f2)
-          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${NEXT_VERSION}|g" README.md
-          sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${NEXT_VERSION}\"|" mkdocs.yml
-          sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${NEXT_VERSION}\`|g" CLAUDE.md
+          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" README.md
+          sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${VERSION}\"|" mkdocs.yml
+          sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${VERSION}\`|g" CLAUDE.md
           git add gradle.properties README.md mkdocs.yml CLAUDE.md
           git commit -m "🔖 Bump version to $NEXT_VERSION"
           git push origin "$BRANCH"

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -37,6 +37,17 @@ jobs:
             echo "No changes since $LAST_TAG — skipping publish"
           fi
 
+      - name: Verify llms-full.txt is up to date
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          cp docs/llms-full.txt /tmp/llms-full-before.txt
+          bash scripts/generate-llms-full.sh
+          if ! diff -q /tmp/llms-full-before.txt docs/llms-full.txt > /dev/null 2>&1; then
+            echo "::error::docs/llms-full.txt is out of date. Run: bash scripts/generate-llms-full.sh"
+            exit 1
+          fi
+          echo "llms-full.txt is up to date"
+
       - name: set up JDK 17
         if: steps.changes.outputs.has_changes == 'true'
         uses: actions/setup-java@v4
@@ -109,8 +120,7 @@ jobs:
           sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" README.md
           sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${VERSION}\"|" mkdocs.yml
           sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${VERSION}\`|g" CLAUDE.md
-          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" docs/llms-full.txt
-          sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" docs/llms-full.txt
+          bash scripts/generate-llms-full.sh
           sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" AGENTS.md
           sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" AGENTS.md
           git add gradle.properties README.md mkdocs.yml CLAUDE.md AGENTS.md docs/llms-full.txt

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -7,6 +7,43 @@ on:
       - master
       - main
 jobs:
+  version_check:
+    name: 'verify doc versions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+
+      - name: Check version consistency
+        run: |
+          VERSION=$(grep '^POM_VERSION=' gradle.properties | cut -d'=' -f2)
+          GROUP_ID=$(grep '^POM_GROUP_ID=' gradle.properties | cut -d'=' -f2)
+          ERRORS=0
+
+          if ! grep -q "${GROUP_ID}:anchor:${VERSION}" README.md; then
+            echo "::error file=README.md::Version mismatch — expected ${GROUP_ID}:anchor:${VERSION}"
+            ERRORS=$((ERRORS+1))
+          fi
+
+          if ! grep -q "version: \"${VERSION}\"" mkdocs.yml; then
+            echo "::error file=mkdocs.yml::Version mismatch in extra.version — expected ${VERSION}"
+            ERRORS=$((ERRORS+1))
+          fi
+
+          if ! grep -q "Published version: \`${VERSION}\`" CLAUDE.md; then
+            echo "::error file=CLAUDE.md::Version mismatch — expected ${VERSION}"
+            ERRORS=$((ERRORS+1))
+          fi
+
+          if [ $ERRORS -gt 0 ]; then
+            echo "::error::Found $ERRORS version mismatch(es). Update docs to match POM_VERSION=${VERSION} in gradle.properties."
+            exit 1
+          fi
+
+          echo "All version references are consistent (${VERSION})"
+
   pr_check:
     name: 'build and test'
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -18,31 +18,28 @@ jobs:
 
       - name: Check version consistency
         run: |
-          VERSION=$(grep '^POM_VERSION=' gradle.properties | cut -d'=' -f2)
           GROUP_ID=$(grep '^POM_GROUP_ID=' gradle.properties | cut -d'=' -f2)
+          DOCS_VERSION=$(grep -oP 'version: "\K[0-9]+\.[0-9]+\.[0-9]+' mkdocs.yml)
+          CLAUDE_VERSION=$(grep -oP 'Published version: `\K[0-9]+\.[0-9]+\.[0-9]+' CLAUDE.md)
+          README_VERSION=$(grep -oP "${GROUP_ID}:anchor:\K[0-9]+\.[0-9]+\.[0-9]+" README.md | head -1)
           ERRORS=0
 
-          if ! grep -q "${GROUP_ID}:anchor:${VERSION}" README.md; then
-            echo "::error file=README.md::Version mismatch — expected ${GROUP_ID}:anchor:${VERSION}"
+          if [ "$README_VERSION" != "$DOCS_VERSION" ]; then
+            echo "::error file=README.md::Version $README_VERSION does not match mkdocs.yml ($DOCS_VERSION)"
             ERRORS=$((ERRORS+1))
           fi
 
-          if ! grep -q "version: \"${VERSION}\"" mkdocs.yml; then
-            echo "::error file=mkdocs.yml::Version mismatch in extra.version — expected ${VERSION}"
-            ERRORS=$((ERRORS+1))
-          fi
-
-          if ! grep -q "Published version: \`${VERSION}\`" CLAUDE.md; then
-            echo "::error file=CLAUDE.md::Version mismatch — expected ${VERSION}"
+          if [ "$CLAUDE_VERSION" != "$DOCS_VERSION" ]; then
+            echo "::error file=CLAUDE.md::Version $CLAUDE_VERSION does not match mkdocs.yml ($DOCS_VERSION)"
             ERRORS=$((ERRORS+1))
           fi
 
           if [ $ERRORS -gt 0 ]; then
-            echo "::error::Found $ERRORS version mismatch(es). Update docs to match POM_VERSION=${VERSION} in gradle.properties."
+            echo "::error::Found $ERRORS version mismatch(es). Ensure README.md, mkdocs.yml, and CLAUDE.md all reference the same published version."
             exit 1
           fi
 
-          echo "All version references are consistent (${VERSION})"
+          echo "All doc version references are consistent ($DOCS_VERSION)"
 
   pr_check:
     name: 'build and test'

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -41,6 +41,26 @@ jobs:
 
           echo "All doc version references are consistent ($DOCS_VERSION)"
 
+  llms_check:
+    name: 'verify llms-full.txt is up to date'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+
+      - name: Regenerate and compare
+        run: |
+          cp docs/llms-full.txt /tmp/llms-full-before.txt
+          bash scripts/generate-llms-full.sh
+          if ! diff -q /tmp/llms-full-before.txt docs/llms-full.txt > /dev/null 2>&1; then
+            echo "::error file=docs/llms-full.txt::llms-full.txt is out of date. Run: bash scripts/generate-llms-full.sh"
+            diff /tmp/llms-full-before.txt docs/llms-full.txt || true
+            exit 1
+          fi
+          echo "llms-full.txt is up to date"
+
   pr_check:
     name: 'build and test'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-macros-plugin
       - run: pip install pillow cairosvg
       - run: mkdocs gh-deploy --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+# Anchor
+
+Anchor is a state management architecture for Kotlin Multiplatform with Jetpack Compose integration. It uses Unidirectional Data Flow (UDF) with immutable state, receiver-based DSLs, and Flow-based reactivity.
+
+- **Repository**: https://github.com/kioba/anchor
+- **Docs**: https://kioba.github.io/anchor/
+- **Published version**: 0.1.0
+- **Platforms**: Android, iOS (iosX64, iosArm64, iosSimulatorArm64), Desktop (JVM)
+
+## Modules
+
+```kotlin
+dependencies {
+    implementation("dev.kioba.anchor:anchor:0.1.0")        // Core state management
+    implementation("dev.kioba.anchor:anchor-compose:0.1.0") // Compose bindings
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.0") // Testing DSL
+}
+```
+
+## Architecture
+
+The core abstraction is `Anchor<R, S>` where `R : Effect` (dependencies) and `S : ViewState` (state). It provides:
+
+- `reduce { copy(...) }` — Immutable state updates
+- `effect { dependency.call() }` — Side effects with injected dependencies
+- `cancellable(key) { ... }` — Auto-cancelling keyed operations
+- `post { MySignal }` — One-time UI signals (navigation, toasts)
+- `emit { MyEvent }` — Internal events for subscription chains
+
+## Creating a Feature
+
+### 1. Define state and markers
+
+```kotlin
+data class MyState(val value: Int = 0) : ViewState
+
+class MyEffect(val api: ApiClient) : Effect
+
+sealed interface MySignal : Signal {
+    data object Success : MySignal
+}
+```
+
+### 2. Create anchor factory
+
+```kotlin
+typealias MyAnchor = Anchor<MyEffect, MyState>
+
+fun RememberAnchorScope.myAnchor(): MyAnchor =
+    create(
+        initialState = ::MyState,
+        effectScope = { MyEffect(api = ApiClient()) },
+        init = { /* runs once on creation */ },
+        subscriptions = { /* reactive event chains */ }
+    )
+```
+
+### 3. Define actions as extension functions
+
+```kotlin
+suspend fun MyAnchor.loadData() {
+    reduce { copy(isLoading = true) }
+    val result = effect { api.fetchData() }
+    reduce { copy(value = result, isLoading = false) }
+    post { MySignal.Success }
+}
+
+suspend fun MyAnchor.search(query: String) {
+    cancellable(key = "search") {
+        delay(300) // debounce
+        val results = effect { api.search(query) }
+        reduce { copy(results = results) }
+    }
+}
+```
+
+### 4. Compose UI
+
+```kotlin
+@Composable
+fun MyScreen() {
+    RememberAnchor(scope = { myAnchor() }) {
+        HandleSignal<MySignal> { signal -> /* handle one-time events */ }
+
+        val value = collectState { it.value }  // granular recomposition
+
+        Button(onClick = anchor(MyAnchor::loadData)) {
+            Text("Load: $value")
+        }
+    }
+}
+```
+
+### 5. Test
+
+```kotlin
+@Test
+fun `loadData updates state and posts signal`() {
+    runAnchorTest(RememberAnchorScope::myAnchor) {
+        given("initial state") {
+            initialState { MyState(value = 0) }
+            effectScope { MyEffect(api = FakeApi()) }
+        }
+
+        on("loading data", MyAnchor::loadData)
+
+        verify("state updated and signal posted") {
+            assertState { copy(isLoading = true) }
+            assertState { copy(value = 42, isLoading = false) }
+            assertSignal { MySignal.Success }
+        }
+    }
+}
+```
+
+## Key Compose APIs
+
+| API | Purpose |
+|-----|---------|
+| `RememberAnchor(scope) { }` | Sets up ViewModel-scoped Anchor with state collection |
+| `collectState { it.field }` | Granular state observation (preferred over `state`) |
+| `anchor(MyAnchor::action)` | Type-safe callback for UI events (0-3 params) |
+| `HandleSignal<T> { }` | Handles one-time signals (navigation, toasts) |
+| `PreviewAnchor(state) { }` | Static state for `@Preview` composables |
+
+## Build & Test
+
+```bash
+./gradlew allTests           # All platforms
+./gradlew desktopTest        # Desktop/JVM
+./gradlew testDebugUnitTest  # Android debug
+./gradlew check              # Tests + lint
+./gradlew build              # Build all modules
+```
+
+## Constraints
+
+- **Immutability**: Always use `reduce { copy(...) }` for state updates. Never mutate state directly.
+- **Explicit API**: The library uses `kotlin { explicitApi() }` — all public APIs need explicit visibility modifiers and return types.
+- **Dispatchers**: Actions run on `Dispatchers.Default`. State collection on `Main.immediate`. Effects default to `Dispatchers.IO`.
+- **Type safety**: Actions are extension functions on specific Anchor types. Use function references (`::increment`) over lambdas.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,7 +429,7 @@ Each new `search()` call cancels the previous job with key `"search"`.
 
 ### Current Version
 
-Published version: `0.1.1` (see `gradle.properties:16`)
+Published version: `0.1.0` (see `gradle.properties:16`)
 
 ## Common Issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,7 +429,7 @@ Each new `search()` call cancels the previous job with key `"search"`.
 
 ### Current Version
 
-Published version: `0.0.8` (see `anchor/build.gradle.kts:102`)
+Published version: `0.1.0` (see `gradle.properties:16`)
 
 ## Common Issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,7 +429,7 @@ Each new `search()` call cancels the previous job with key `"search"`.
 
 ### Current Version
 
-Published version: `0.1.0` (see `gradle.properties:16`)
+Published version: `0.1.1` (see `gradle.properties:16`)
 
 ## Common Issues
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Visit [kioba.github.io/anchor/](https://kioba.github.io/anchor/) for the full do
 
 ## 📦 Installation
 
-Add the dependency to your `build.gradle.kts`:
+Add the dependencies to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kioba.anchor:anchor:0.0.10")
+    implementation("dev.kioba.anchor:anchor:0.1.0")
+    implementation("dev.kioba.anchor:anchor-compose:0.1.0")
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the dependencies to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kioba.anchor:anchor:0.1.0")
+    implementation("dev.kioba.anchor:anchor:0.1.1")
     implementation("dev.kioba.anchor:anchor-compose:0.1.0")
     testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the dependencies to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kioba.anchor:anchor:0.1.1")
+    implementation("dev.kioba.anchor:anchor:0.1.0")
     implementation("dev.kioba.anchor:anchor-compose:0.1.0")
     testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
 }

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,0 +1,215 @@
+# Compose Integration
+
+The `anchor-compose` module provides Jetpack Compose bindings for Anchor. It connects the Anchor state machine to the Compose lifecycle, giving you type-safe state observation, action dispatching, and signal handling — all scoped to a ViewModel.
+
+**Why a separate module?** Keeping Compose dependencies out of the core `anchor` module means your shared business logic stays free of UI framework dependencies. This is especially important for Kotlin Multiplatform projects where not every target uses Compose.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("{{ group_id }}:anchor-compose:{{ version }}")
+}
+```
+
+!!! note
+    `anchor-compose` transitively includes the core `anchor` module, so you don't need to add both.
+
+---
+
+## RememberAnchor
+
+`RememberAnchor` is the primary composable that sets up an Anchor-powered screen. It creates a ViewModel-scoped Anchor instance, collects state, and provides the necessary CompositionLocals for `anchor()` and `HandleSignal`.
+
+```kotlin
+@Composable
+fun CounterScreen() {
+    RememberAnchor(scope = { counterAnchor() }) {
+        val count = collectState { it.count }
+
+        Text("Count: $count")
+        Button(onClick = anchor(CounterAnchor::increment)) {
+            Text("+")
+        }
+    }
+}
+```
+
+### Parameters
+
+| Parameter   | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `scope`     | Factory that creates the Anchor instance (called once per ViewModel)        |
+| `customKey` | Optional key for ViewModel storage (defaults to the ViewState class name)   |
+| `content`   | Composable block receiving `AnchorStateScope<S>`                            |
+
+### Lifecycle
+
+1. On first composition, `RememberAnchor` creates a `ContainerViewModel` that holds the `AnchorRuntime`
+2. The Anchor's `init` block runs once, and `subscriptions` are set up
+3. State is collected via `collectAsStateWithLifecycle()` on `Main.immediate`
+4. The ViewModel survives configuration changes — state is retained automatically
+
+---
+
+## Observing State
+
+Inside `RememberAnchor`, you have access to `AnchorStateScope<S>` which provides two ways to observe state:
+
+### `state` — Full state access
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    Text("Count: ${state.count}")
+}
+```
+
+Any change to the state triggers recomposition of the entire content block.
+
+### `collectState` — Granular recomposition
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    val count = collectState { it.count }
+    val isLoading = collectState { it.isLoading }
+
+    // Only recomposes when the selected value changes,
+    // not when other state fields change.
+}
+```
+
+`collectState` applies a selector function and only triggers recomposition when the selected value changes. Prefer this for screens with many state fields.
+
+---
+
+## Dispatching Actions
+
+The `anchor()` composable creates type-safe callbacks from Anchor action functions. It supports 0 to 3 parameters:
+
+```kotlin
+// No parameters — returns () -> Unit
+Button(onClick = anchor(CounterAnchor::increment)) {
+    Text("+")
+}
+
+// One parameter — returns (I) -> Unit
+TextField(onValueChange = anchor(ConfigAnchor::updateText))
+
+// Two parameters — returns (I, O) -> Unit
+CustomSlider(onChange = anchor(SettingsAnchor::updateRange))
+```
+
+Actions are executed asynchronously on `Dispatchers.Default` within the ViewModel's coroutine scope.
+
+---
+
+## Handling Signals
+
+Signals are one-time events (navigation, snackbars, toasts) that shouldn't persist in state. Use `HandleSignal` to react to them:
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    HandleSignal<CounterSignal> { signal ->
+        when (signal) {
+            CounterSignal.Increment -> snackbarHostState.showSnackbar("Incremented!")
+            CounterSignal.Decrement -> snackbarHostState.showSnackbar("Decremented!")
+        }
+    }
+
+    // ... UI content
+}
+```
+
+`HandleSignal` uses `LaunchedEffect` internally — it respects the composable lifecycle and automatically stops collecting when the composable leaves the composition.
+
+---
+
+## Compose Previews
+
+Use `PreviewAnchor` to provide static state for `@Preview` composables without needing a full Anchor setup:
+
+```kotlin
+@Preview
+@Composable
+fun CounterPreview() {
+    PreviewAnchor(state = CounterState(count = 42)) {
+        val count = collectState { it.count }
+        Text("Count: $count")
+    }
+}
+```
+
+`PreviewAnchor` wraps the state in an `AnchorStateScope` so your content composable works identically to production. Actions dispatched via `anchor()` become no-ops in previews.
+
+---
+
+## Full Example
+
+Putting it all together:
+
+```kotlin
+// State
+data class CounterState(
+    val count: Int = 0,
+) : ViewState
+
+// Signals
+sealed interface CounterSignal : Signal {
+    data object Increment : CounterSignal
+    data object Decrement : CounterSignal
+}
+
+// Anchor factory
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+
+fun RememberAnchorScope.counterAnchor(): CounterAnchor =
+    create(initialState = ::CounterState, effectScope = { EmptyEffect })
+
+// Actions
+suspend fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }
+    post { CounterSignal.Increment }
+}
+
+suspend fun CounterAnchor.decrement() {
+    reduce { copy(count = count - 1) }
+    post { CounterSignal.Decrement }
+}
+
+// UI
+@Composable
+fun CounterScreen(snackbarHostState: SnackbarHostState) {
+    RememberAnchor(scope = { counterAnchor() }) {
+        HandleSignal<CounterSignal> { signal ->
+            val message = when (signal) {
+                CounterSignal.Increment -> "Incremented"
+                CounterSignal.Decrement -> "Decremented"
+            }
+            snackbarHostState.showSnackbar(message)
+        }
+
+        val count = collectState { it.count }
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Row {
+                Button(onClick = anchor(CounterAnchor::decrement)) { Text("-") }
+                Button(onClick = anchor(CounterAnchor::increment)) { Text("+") }
+            }
+        }
+    }
+}
+
+// Preview
+@Preview
+@Composable
+fun CounterPreview() {
+    PreviewAnchor(state = CounterState(count = 10)) {
+        val count = collectState { it.count }
+        Text("Count: $count")
+    }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,29 +19,21 @@ Anchor is a simple, lightweight, and extensible state management architecture bu
 
 ## Installation
 
-Add the following to your `build.gradle.kts` file:
-
-### 1. Add the GitHub Packages Repository
-
-```kotlin
-repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/kioba/anchor")
-        credentials {
-            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
-        }
-    }
-}
-```
-
-### 2. Add the Dependency
+Anchor is available on Maven Central. Add the dependencies to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("dev.kioba:anchor:0.0.8")
+    implementation("{{ group_id }}:anchor:{{ version }}")
+    implementation("{{ group_id }}:anchor-compose:{{ version }}")
+    testImplementation("{{ group_id }}:anchor-test:{{ version }}")
 }
 ```
+
+| Module | Purpose |
+|--------|---------|
+| `anchor` | Core state management (ViewState, Effect, Anchor, Signals, Events) |
+| `anchor-compose` | Jetpack Compose bindings (RememberAnchor, collectState, anchor(), HandleSignal) |
+| `anchor-test` | BDD-style testing DSL (runAnchorTest, given/on/verify) |
 
 ## Quick Start (Counter Example)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10,11 +10,11 @@
 
 ---
 
-# Introduction
+# Welcome to ⚓️ anchor
+
 
 Anchor is a simple, lightweight, and extensible state management architecture built on Kotlin's Context receivers with Jetpack Compose integration for Kotlin Multiplatform projects.
 
-**Goal**: Focus on writing an amazing app and let Anchor handle the state and side effects!
 
 ## Key Features
 
@@ -45,6 +45,8 @@ dependencies {
 
 ## Quick Start (Counter Example)
 
+Here's a simple counter example to get you started:
+
 ```kotlin
 // 1. Define your State
 data class CounterState(val count: Int = 0) : ViewState
@@ -72,6 +74,30 @@ fun CounterScreen() {
 }
 ```
 
+## Next Steps
+
+- Explore the [Core Concepts](https://kioba.github.io/anchor/concepts/) to understand how Anchor works.
+- Check the [API Reference](https://kioba.github.io/anchor/api/) for detailed documentation.
+- See more [Examples](https://kioba.github.io/anchor/examples/) for real-world usage.
+
+---
+
+## License
+
+    Copyright 2026 Karoly Somodi
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 ---
 
 # Core Concepts
@@ -88,6 +114,8 @@ The Anchor architecture consists of the following main components:
 - **Actions**: Functions that define how to modify state or trigger side effects.
 - **Signals**: One-time messages sent from the Anchor to the UI.
 - **Events**: Internal messages within the Anchor used for complex logic.
+
+---
 
 ## ViewState
 
@@ -183,7 +211,9 @@ dependencies {
 }
 ```
 
-Note: `anchor-compose` transitively includes the core `anchor` module, so you don't need to add both.
+    `anchor-compose` transitively includes the core `anchor` module, so you don't need to add both.
+
+---
 
 ## RememberAnchor
 
@@ -205,9 +235,11 @@ fun CounterScreen() {
 
 ### Parameters
 
-- `scope`: Factory that creates the Anchor instance (called once per ViewModel)
-- `customKey`: Optional key for ViewModel storage (defaults to the ViewState class name)
-- `content`: Composable block receiving `AnchorStateScope<S>`
+| Parameter   | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `scope`     | Factory that creates the Anchor instance (called once per ViewModel)        |
+| `customKey` | Optional key for ViewModel storage (defaults to the ViewState class name)   |
+| `content`   | Composable block receiving `AnchorStateScope<S>`                            |
 
 ### Lifecycle
 
@@ -215,6 +247,8 @@ fun CounterScreen() {
 2. The Anchor's `init` block runs once, and `subscriptions` are set up
 3. State is collected via `collectAsStateWithLifecycle()` on `Main.immediate`
 4. The ViewModel survives configuration changes — state is retained automatically
+
+---
 
 ## Observing State
 
@@ -244,6 +278,8 @@ RememberAnchor(scope = { counterAnchor() }) {
 
 `collectState` applies a selector function and only triggers recomposition when the selected value changes. Prefer this for screens with many state fields.
 
+---
+
 ## Dispatching Actions
 
 The `anchor()` composable creates type-safe callbacks from Anchor action functions. It supports 0 to 3 parameters:
@@ -262,6 +298,8 @@ CustomSlider(onChange = anchor(SettingsAnchor::updateRange))
 ```
 
 Actions are executed asynchronously on `Dispatchers.Default` within the ViewModel's coroutine scope.
+
+---
 
 ## Handling Signals
 
@@ -282,6 +320,8 @@ RememberAnchor(scope = { counterAnchor() }) {
 
 `HandleSignal` uses `LaunchedEffect` internally — it respects the composable lifecycle and automatically stops collecting when the composable leaves the composition.
 
+---
+
 ## Compose Previews
 
 Use `PreviewAnchor` to provide static state for `@Preview` composables without needing a full Anchor setup:
@@ -299,7 +339,11 @@ fun CounterPreview() {
 
 `PreviewAnchor` wraps the state in an `AnchorStateScope` so your content composable works identically to production. Actions dispatched via `anchor()` become no-ops in previews.
 
-## Full Compose Example
+---
+
+## Full Example
+
+Putting it all together:
 
 ```kotlin
 // State
@@ -382,7 +426,9 @@ dependencies {
 }
 ```
 
-Note: `anchor-test` transitively includes the core `anchor` module and `kotlinx-coroutines-test`.
+    `anchor-test` transitively includes the core `anchor` module and `kotlinx-coroutines-test`.
+
+---
 
 ## runAnchorTest
 
@@ -407,6 +453,8 @@ fun `counter increment updates state`() {
 ```
 
 The test uses a `AnchorTestRuntime` under the hood — a recording implementation that captures every `reduce`, `post`, `emit`, and `effect` call in order, then replays your assertions against the recording.
+
+---
 
 ## Given — Setup
 
@@ -434,6 +482,8 @@ given("the API returns a specific user") {
 }
 ```
 
+---
+
 ## On — Action
 
 The `on` block specifies which action to execute. You can pass a function reference or a lambda:
@@ -447,6 +497,8 @@ on("updating the text") {
     updateText("Hello")
 }
 ```
+
+---
 
 ## Verify — Assertions
 
@@ -510,7 +562,9 @@ verify("state updated and signal posted") {
 }
 ```
 
-## Test Examples
+---
+
+## Examples
 
 ### Basic state and signal test
 
@@ -574,7 +628,7 @@ fun `refresh triggers the subscription`() {
 
 ### Skipping the given block
 
-If you don't need custom setup, you can omit the `given` block entirely:
+If you don't need custom setup, you can omit the `given` block entirely. The test will use the anchor factory's default state and effect scope:
 
 ```kotlin
 @Test
@@ -593,6 +647,8 @@ fun `sayHi sets the details`() {
 
 # API Reference
 
+This page provides a detailed reference for the public API of the Anchor library.
+
 ## Core API
 
 ### `Anchor<E, S>`
@@ -606,6 +662,8 @@ The main interface for state management.
 - `post(block: SignalScope.() -> Signal)`: Posts a signal to the UI.
 - `emit(block: SubscriptionScope.() -> Event)`: Emits an internal event.
 
+---
+
 ### `RememberAnchorScope.create(...)`
 
 Creates an `Anchor` instance.
@@ -615,7 +673,9 @@ Creates an `Anchor` instance.
 - `init`: Optional initialization block.
 - `subscriptions`: Optional subscription setup block.
 
-## Compose API
+---
+
+## Compose API (Android)
 
 ### `RememberAnchor(scope, customKey, content)`
 
@@ -625,12 +685,16 @@ Sets up Anchor in a Composable.
 - `customKey`: Optional key for state retention.
 - `content`: Composable block receiving `AnchorStateScope`.
 
+---
+
 ### `AnchorStateScope<S>`
 
 Scope available inside `RememberAnchor`.
 
 - `state`: Accesses the current state (triggers recomposition for any change).
 - `collectState(selector: (S) -> T): T`: Observes a specific part of the state (granular recomposition).
+
+---
 
 ### `anchor(block)`
 
@@ -639,6 +703,8 @@ Helper to create UI action callbacks.
 - `anchor(suspend A.() -> Unit): () -> Unit`
 - `anchor(suspend A.(I) -> Unit): (I) -> Unit`
 - `anchor(suspend A.(I, O) -> Unit): (I, O) -> Unit`
+
+---
 
 ### `HandleSignal<T>(block)`
 
@@ -649,6 +715,8 @@ HandleSignal<MySignal> { signal ->
     // Handle the signal
 }
 ```
+
+---
 
 ### `PreviewAnchor(state, content)`
 
@@ -754,3 +822,4 @@ fun CounterPage() {
     }
 }
 ```
+

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,756 @@
+# Anchor — Complete Documentation
+
+> A lightweight, type-safe state management architecture for Kotlin Multiplatform with Jetpack Compose integration.
+
+- Repository: https://github.com/kioba/anchor
+- Published version: 0.1.0
+- Group ID: dev.kioba.anchor
+- Artifacts: anchor, anchor-compose, anchor-test
+- Platforms: Android, iOS (iosX64, iosArm64, iosSimulatorArm64), Desktop (JVM)
+
+---
+
+# Introduction
+
+Anchor is a simple, lightweight, and extensible state management architecture built on Kotlin's Context receivers with Jetpack Compose integration for Kotlin Multiplatform projects.
+
+**Goal**: Focus on writing an amazing app and let Anchor handle the state and side effects!
+
+## Key Features
+
+- **Built for Compose**: Native integration with Jetpack Compose.
+- **Kotlin Multiplatform**: Supports Android and iOS.
+- **Type-Safe**: Leverages Kotlin's type system for state, effects, signals, and events.
+- **Lifecycle-Aware**: Automatically manages Anchor instances within ViewModels, retaining state across configuration changes.
+- **Context Receivers**: Uses modern Kotlin features for a clean and expressive DSL.
+- **Granular Recomposition**: Provides utilities to observe only the necessary parts of the state.
+
+## Installation
+
+Anchor is available on Maven Central. Add the dependencies to your `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("dev.kioba.anchor:anchor:0.1.0")
+    implementation("dev.kioba.anchor:anchor-compose:0.1.0")
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
+}
+```
+
+| Module | Purpose |
+|--------|---------|
+| `anchor` | Core state management (ViewState, Effect, Anchor, Signals, Events) |
+| `anchor-compose` | Jetpack Compose bindings (RememberAnchor, collectState, anchor(), HandleSignal) |
+| `anchor-test` | BDD-style testing DSL (runAnchorTest, given/on/verify) |
+
+## Quick Start (Counter Example)
+
+```kotlin
+// 1. Define your State
+data class CounterState(val count: Int = 0) : ViewState
+
+// 2. Define your Anchor
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+
+fun RememberAnchorScope.counterAnchor(): CounterAnchor =
+    create(initialState = ::CounterState, effectScope = { EmptyEffect })
+
+// 3. Define Actions
+fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }
+}
+
+// 4. Use in UI
+@Composable
+fun CounterScreen() {
+    RememberAnchor(scope = { counterAnchor() }) {
+        val count = collectState { it.count }
+        Button(onClick = anchor(CounterAnchor::increment)) {
+            Text("Count: $count")
+        }
+    }
+}
+```
+
+---
+
+# Core Concepts
+
+Anchor is based on a few core concepts that work together to manage state and side effects in a predictable way.
+
+## Overview
+
+The Anchor architecture consists of the following main components:
+
+- **ViewState**: The immutable representation of the UI state.
+- **Effect**: Dependencies required for side effects (e.g., repositories, services).
+- **Anchor**: The engine that manages state, executes effects, and handles communication.
+- **Actions**: Functions that define how to modify state or trigger side effects.
+- **Signals**: One-time messages sent from the Anchor to the UI.
+- **Events**: Internal messages within the Anchor used for complex logic.
+
+## ViewState
+
+`ViewState` is a marker interface for your UI state. It should typically be an immutable `data class`.
+
+```kotlin
+data class MyState(
+    val isLoading: Boolean = false,
+    val items: List<String> = emptyList(),
+    val error: String? = null
+) : ViewState
+```
+
+## Effect
+
+`Effect` is a marker interface for dependencies used in side effects. This allows you to keep your Anchor logic pure and testable by injecting dependencies.
+
+```kotlin
+class MyEffect(
+    val repository: MyRepository
+) : Effect
+```
+
+## Anchor
+
+The `Anchor` is the central component. It manages the `ViewState` and provides a DSL for:
+
+- **reduce**: Updating the state.
+- **effect**: Executing suspendable side effects.
+- **cancellable**: Managing long-running jobs that can be cancelled.
+- **post**: Sending signals to the UI.
+- **emit**: Emitting internal events.
+
+## Actions
+
+Actions are usually extension functions on your specific `Anchor` type. They encapsulate the business logic.
+
+```kotlin
+suspend fun MyAnchor.loadData() {
+    reduce { copy(isLoading = true) }
+    try {
+        val result = effect { repository.fetchData() }
+        reduce { copy(isLoading = false, items = result) }
+    } catch (e: Exception) {
+        reduce { copy(isLoading = false, error = e.message) }
+    }
+}
+```
+
+## Signals
+
+`Signal`s are one-time messages for things that aren't part of the persistent state, like showing a Snackbar, a Toast, or navigating.
+
+```kotlin
+sealed interface MySignal : Signal {
+    data class ShowError(val message: String) : MySignal
+}
+
+// In an Action:
+post { MySignal.ShowError("Something went wrong") }
+
+// In UI:
+HandleSignal<MySignal.ShowError> { signal ->
+    snackbarHostState.showSnackbar(signal.message)
+}
+```
+
+## Events & Subscriptions
+
+`Event`s are internal messages. They are useful for complex logic where one action triggers another, or for reacting to lifecycle events like `Created`.
+
+```kotlin
+subscriptions = {
+    listen<Created> { events ->
+        events.anchor { loadData() }
+    }
+}
+```
+
+---
+
+# Compose Integration
+
+The `anchor-compose` module provides Jetpack Compose bindings for Anchor. It connects the Anchor state machine to the Compose lifecycle, giving you type-safe state observation, action dispatching, and signal handling — all scoped to a ViewModel.
+
+**Why a separate module?** Keeping Compose dependencies out of the core `anchor` module means your shared business logic stays free of UI framework dependencies. This is especially important for Kotlin Multiplatform projects where not every target uses Compose.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("dev.kioba.anchor:anchor-compose:0.1.0")
+}
+```
+
+Note: `anchor-compose` transitively includes the core `anchor` module, so you don't need to add both.
+
+## RememberAnchor
+
+`RememberAnchor` is the primary composable that sets up an Anchor-powered screen. It creates a ViewModel-scoped Anchor instance, collects state, and provides the necessary CompositionLocals for `anchor()` and `HandleSignal`.
+
+```kotlin
+@Composable
+fun CounterScreen() {
+    RememberAnchor(scope = { counterAnchor() }) {
+        val count = collectState { it.count }
+
+        Text("Count: $count")
+        Button(onClick = anchor(CounterAnchor::increment)) {
+            Text("+")
+        }
+    }
+}
+```
+
+### Parameters
+
+- `scope`: Factory that creates the Anchor instance (called once per ViewModel)
+- `customKey`: Optional key for ViewModel storage (defaults to the ViewState class name)
+- `content`: Composable block receiving `AnchorStateScope<S>`
+
+### Lifecycle
+
+1. On first composition, `RememberAnchor` creates a `ContainerViewModel` that holds the `AnchorRuntime`
+2. The Anchor's `init` block runs once, and `subscriptions` are set up
+3. State is collected via `collectAsStateWithLifecycle()` on `Main.immediate`
+4. The ViewModel survives configuration changes — state is retained automatically
+
+## Observing State
+
+Inside `RememberAnchor`, you have access to `AnchorStateScope<S>` which provides two ways to observe state:
+
+### `state` — Full state access
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    Text("Count: ${state.count}")
+}
+```
+
+Any change to the state triggers recomposition of the entire content block.
+
+### `collectState` — Granular recomposition
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    val count = collectState { it.count }
+    val isLoading = collectState { it.isLoading }
+
+    // Only recomposes when the selected value changes,
+    // not when other state fields change.
+}
+```
+
+`collectState` applies a selector function and only triggers recomposition when the selected value changes. Prefer this for screens with many state fields.
+
+## Dispatching Actions
+
+The `anchor()` composable creates type-safe callbacks from Anchor action functions. It supports 0 to 3 parameters:
+
+```kotlin
+// No parameters — returns () -> Unit
+Button(onClick = anchor(CounterAnchor::increment)) {
+    Text("+")
+}
+
+// One parameter — returns (I) -> Unit
+TextField(onValueChange = anchor(ConfigAnchor::updateText))
+
+// Two parameters — returns (I, O) -> Unit
+CustomSlider(onChange = anchor(SettingsAnchor::updateRange))
+```
+
+Actions are executed asynchronously on `Dispatchers.Default` within the ViewModel's coroutine scope.
+
+## Handling Signals
+
+Signals are one-time events (navigation, snackbars, toasts) that shouldn't persist in state. Use `HandleSignal` to react to them:
+
+```kotlin
+RememberAnchor(scope = { counterAnchor() }) {
+    HandleSignal<CounterSignal> { signal ->
+        when (signal) {
+            CounterSignal.Increment -> snackbarHostState.showSnackbar("Incremented!")
+            CounterSignal.Decrement -> snackbarHostState.showSnackbar("Decremented!")
+        }
+    }
+
+    // ... UI content
+}
+```
+
+`HandleSignal` uses `LaunchedEffect` internally — it respects the composable lifecycle and automatically stops collecting when the composable leaves the composition.
+
+## Compose Previews
+
+Use `PreviewAnchor` to provide static state for `@Preview` composables without needing a full Anchor setup:
+
+```kotlin
+@Preview
+@Composable
+fun CounterPreview() {
+    PreviewAnchor(state = CounterState(count = 42)) {
+        val count = collectState { it.count }
+        Text("Count: $count")
+    }
+}
+```
+
+`PreviewAnchor` wraps the state in an `AnchorStateScope` so your content composable works identically to production. Actions dispatched via `anchor()` become no-ops in previews.
+
+## Full Compose Example
+
+```kotlin
+// State
+data class CounterState(
+    val count: Int = 0,
+) : ViewState
+
+// Signals
+sealed interface CounterSignal : Signal {
+    data object Increment : CounterSignal
+    data object Decrement : CounterSignal
+}
+
+// Anchor factory
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+
+fun RememberAnchorScope.counterAnchor(): CounterAnchor =
+    create(initialState = ::CounterState, effectScope = { EmptyEffect })
+
+// Actions
+suspend fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }
+    post { CounterSignal.Increment }
+}
+
+suspend fun CounterAnchor.decrement() {
+    reduce { copy(count = count - 1) }
+    post { CounterSignal.Decrement }
+}
+
+// UI
+@Composable
+fun CounterScreen(snackbarHostState: SnackbarHostState) {
+    RememberAnchor(scope = { counterAnchor() }) {
+        HandleSignal<CounterSignal> { signal ->
+            val message = when (signal) {
+                CounterSignal.Increment -> "Incremented"
+                CounterSignal.Decrement -> "Decremented"
+            }
+            snackbarHostState.showSnackbar(message)
+        }
+
+        val count = collectState { it.count }
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+            Row {
+                Button(onClick = anchor(CounterAnchor::decrement)) { Text("-") }
+                Button(onClick = anchor(CounterAnchor::increment)) { Text("+") }
+            }
+        }
+    }
+}
+
+// Preview
+@Preview
+@Composable
+fun CounterPreview() {
+    PreviewAnchor(state = CounterState(count = 10)) {
+        val count = collectState { it.count }
+        Text("Count: $count")
+    }
+}
+```
+
+---
+
+# Testing
+
+The `anchor-test` module provides a BDD-style DSL for testing Anchor actions. It lets you verify state changes, signals, events, and effects deterministically — without Compose, ViewModels, or coroutine complexity.
+
+## Installation
+
+```kotlin
+dependencies {
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
+}
+```
+
+Note: `anchor-test` transitively includes the core `anchor` module and `kotlinx-coroutines-test`.
+
+## runAnchorTest
+
+`runAnchorTest` is the entry point for all Anchor tests. Pass it the same anchor factory you use in production, then structure your test with `given`, `on`, and `verify` blocks.
+
+```kotlin
+@Test
+fun `counter increment updates state`() {
+    runAnchorTest(RememberAnchorScope::counterAnchor) {
+        given("the screen started") {
+            initialState { CounterState(count = -1) }
+        }
+
+        on("incrementing the counter", CounterAnchor::increment)
+
+        verify("the state updated with the incremented value") {
+            assertState { copy(count = 0) }
+            assertSignal { CounterSignal.Increment }
+        }
+    }
+}
+```
+
+The test uses a `AnchorTestRuntime` under the hood — a recording implementation that captures every `reduce`, `post`, `emit`, and `effect` call in order, then replays your assertions against the recording.
+
+## Given — Setup
+
+The `given` block sets up preconditions for the test.
+
+### `initialState`
+
+Override the default initial state:
+
+```kotlin
+given("a counter that already has a value") {
+    initialState { CounterState(count = 100) }
+}
+```
+
+The lambda returns the state to start with. If omitted, the anchor factory's default `initialState` is used.
+
+### `effectScope`
+
+Provide a custom effect scope (useful for injecting test doubles):
+
+```kotlin
+given("the API returns a specific user") {
+    effectScope { MyEffect(api = FakeApi()) }
+}
+```
+
+## On — Action
+
+The `on` block specifies which action to execute. You can pass a function reference or a lambda:
+
+```kotlin
+// Function reference
+on("incrementing the counter", CounterAnchor::increment)
+
+// Lambda (for actions with parameters)
+on("updating the text") {
+    updateText("Hello")
+}
+```
+
+## Verify — Assertions
+
+The `verify` block asserts the outcomes of the action. Assertions must be declared **in the same order** the action produces them.
+
+### `assertState`
+
+Verifies a state reduction occurred. The lambda receives the previous state and returns the expected new state:
+
+```kotlin
+verify("the count increased") {
+    assertState { copy(count = count + 1) }
+}
+```
+
+### `assertSignal`
+
+Verifies a signal was posted:
+
+```kotlin
+verify("an increment signal was sent") {
+    assertSignal { CounterSignal.Increment }
+}
+```
+
+### `assertEvent`
+
+Verifies an internal event was emitted:
+
+```kotlin
+verify("a cancel event was emitted") {
+    assertEvent { MainEvent.Cancel }
+}
+```
+
+### `assertEffect`
+
+Verifies an effect block was executed:
+
+```kotlin
+verify("the API was called") {
+    assertEffect { api.fetchData() }
+}
+```
+
+### Ordering
+
+Assertions are matched against recorded actions **in order**. If an action calls `reduce`, then `post`, your verify block must call `assertState` before `assertSignal`:
+
+```kotlin
+// Action
+suspend fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }    // 1st
+    post { CounterSignal.Increment }       // 2nd
+}
+
+// Test
+verify("state updated and signal posted") {
+    assertState { copy(count = 0) }        // matches 1st
+    assertSignal { CounterSignal.Increment } // matches 2nd
+}
+```
+
+## Test Examples
+
+### Basic state and signal test
+
+```kotlin
+@Test
+fun `counter increment updates state`() {
+    runAnchorTest(RememberAnchorScope::counterAnchor) {
+        given("the screen started") {
+            initialState { CounterState(count = -1) }
+        }
+
+        on("incrementing the counter", CounterAnchor::increment)
+
+        verify("the state updated with the incremented value") {
+            assertState { copy(count = 0) }
+            assertSignal { CounterSignal.Increment }
+        }
+    }
+}
+```
+
+### Testing events
+
+```kotlin
+@Test
+fun `clear cancels the counting`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        given("the initial state started to count up") {
+            initialState { mainViewState().copy(hundreds = 100, iterationCounter = "100") }
+        }
+
+        on("clearing", MainAnchor::clear)
+
+        verify("cancel event emitted and state cleared") {
+            assertEvent { MainEvent.Cancel }
+            assertState { copy(details = "cleared", iterationCounter = null) }
+        }
+    }
+}
+```
+
+### Providing a custom effect scope
+
+```kotlin
+@Test
+fun `refresh triggers the subscription`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        given("the screen is ready") {
+            initialState { mainViewState() }
+            effectScope { MainEffect() }
+        }
+
+        on("refreshing", MainAnchor::refresh)
+
+        verify("refresh event emitted") {
+            assertEvent { MainEvent.Refresh }
+        }
+    }
+}
+```
+
+### Skipping the given block
+
+If you don't need custom setup, you can omit the `given` block entirely:
+
+```kotlin
+@Test
+fun `sayHi sets the details`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        on("saying hi", MainAnchor::sayHi)
+
+        verify("the details are set") {
+            assertState { copy(details = "Hello Android!") }
+        }
+    }
+}
+```
+
+---
+
+# API Reference
+
+## Core API
+
+### `Anchor<E, S>`
+
+The main interface for state management.
+
+- `state: S`: The current state.
+- `reduce(reducer: S.() -> S)`: Updates the state.
+- `effect(coroutineContext, block: suspend E.() -> R): R`: Executes a side effect.
+- `cancellable(key, block)`: Executes a block that can be cancelled by a key.
+- `post(block: SignalScope.() -> Signal)`: Posts a signal to the UI.
+- `emit(block: SubscriptionScope.() -> Event)`: Emits an internal event.
+
+### `RememberAnchorScope.create(...)`
+
+Creates an `Anchor` instance.
+
+- `initialState`: Factory for the initial state.
+- `effectScope`: Factory for effect dependencies.
+- `init`: Optional initialization block.
+- `subscriptions`: Optional subscription setup block.
+
+## Compose API
+
+### `RememberAnchor(scope, customKey, content)`
+
+Sets up Anchor in a Composable.
+
+- `scope`: Factory block to create the Anchor.
+- `customKey`: Optional key for state retention.
+- `content`: Composable block receiving `AnchorStateScope`.
+
+### `AnchorStateScope<S>`
+
+Scope available inside `RememberAnchor`.
+
+- `state`: Accesses the current state (triggers recomposition for any change).
+- `collectState(selector: (S) -> T): T`: Observes a specific part of the state (granular recomposition).
+
+### `anchor(block)`
+
+Helper to create UI action callbacks.
+
+- `anchor(suspend A.() -> Unit): () -> Unit`
+- `anchor(suspend A.(I) -> Unit): (I) -> Unit`
+- `anchor(suspend A.(I, O) -> Unit): (I, O) -> Unit`
+
+### `HandleSignal<T>(block)`
+
+Handles one-time signals of type `T`.
+
+```kotlin
+HandleSignal<MySignal> { signal ->
+    // Handle the signal
+}
+```
+
+### `PreviewAnchor(state, content)`
+
+A utility for Compose Previews.
+
+```kotlin
+@Preview
+@Composable
+fun MyPreview() {
+    PreviewAnchor(state = MyState()) {
+        MyUi()
+    }
+}
+```
+
+---
+
+# Examples
+
+## Comprehensive Counter Example
+
+This example demonstrates state, actions, and signals.
+
+### 1. State and Signals
+
+```kotlin
+data class CounterState(
+    val count: Int = 0,
+    val isLoading: Boolean = false
+) : ViewState
+
+sealed interface CounterSignal : Signal {
+    data class ShowToast(val message: String) : CounterSignal
+}
+```
+
+### 2. Anchor Definition
+
+```kotlin
+class CounterEffect : Effect
+
+typealias CounterAnchor = Anchor<CounterEffect, CounterState>
+
+fun RememberAnchorScope.counterAnchor(): CounterAnchor =
+    create(
+        initialState = ::CounterState,
+        effectScope = { CounterEffect() }
+    )
+```
+
+### 3. Actions
+
+```kotlin
+fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }
+}
+
+fun CounterAnchor.decrement() {
+    reduce { copy(count = count - 1) }
+}
+
+suspend fun CounterAnchor.reset() {
+    reduce { copy(isLoading = true) }
+    delay(1000) // Simulate work
+    reduce { copy(count = 0, isLoading = false) }
+    post { CounterSignal.ShowToast("Counter reset!") }
+}
+```
+
+### 4. UI Implementation
+
+```kotlin
+@Composable
+fun CounterPage() {
+    RememberAnchor(scope = { counterAnchor() }) {
+        // Handle signals
+        HandleSignal<CounterSignal.ShowToast> { signal ->
+            // Show toast/snackbar
+        }
+
+        val count = collectState { it.count }
+        val isLoading = collectState { it.isLoading }
+
+        Column {
+            Text("Count: $count")
+
+            if (isLoading) {
+                CircularProgressIndicator()
+            } else {
+                Row {
+                    Button(onClick = anchor(CounterAnchor::increment)) {
+                        Text("+")
+                    }
+                    Button(onClick = anchor(CounterAnchor::decrement)) {
+                        Text("-")
+                    }
+                    Button(onClick = anchor(CounterAnchor::reset)) {
+                        Text("Reset")
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,23 @@
+# Anchor
+
+> A lightweight, type-safe state management architecture for Kotlin Multiplatform with Jetpack Compose integration.
+
+Anchor uses Unidirectional Data Flow (UDF) with immutable state, receiver-based DSLs, and Flow-based reactivity. It targets Android, iOS (via iosX64, iosArm64, iosSimulatorArm64), and Desktop (JVM).
+
+## Docs
+
+- [Introduction](https://kioba.github.io/anchor/): Installation, quick start, and feature overview
+- [Core Concepts](https://kioba.github.io/anchor/concepts/): ViewState, Effect, Anchor engine, Actions, Signals, Events & Subscriptions
+- [Compose Integration](https://kioba.github.io/anchor/compose/): RememberAnchor, collectState, anchor() callbacks, HandleSignal, PreviewAnchor
+- [Testing](https://kioba.github.io/anchor/testing/): BDD-style testing DSL with runAnchorTest, given/on/verify, assertions
+- [API Reference](https://kioba.github.io/anchor/api/): Complete public API surface for core and Compose modules
+- [Examples](https://kioba.github.io/anchor/examples/): End-to-end counter example with state, signals, and async operations
+
+## Source
+
+- [GitHub Repository](https://github.com/kioba/anchor)
+- [AGENTS.md](https://github.com/kioba/anchor/blob/master/AGENTS.md): Build commands, architecture, development patterns
+
+## Optional
+
+- [Full Documentation](https://kioba.github.io/anchor/llms-full.txt): Complete documentation in a single file

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,229 @@
+# Testing
+
+The `anchor-test` module provides a BDD-style DSL for testing Anchor actions. It lets you verify state changes, signals, events, and effects deterministically — without Compose, ViewModels, or coroutine complexity.
+
+## Installation
+
+```kotlin
+dependencies {
+    testImplementation("{{ group_id }}:anchor-test:{{ version }}")
+}
+```
+
+!!! note
+    `anchor-test` transitively includes the core `anchor` module and `kotlinx-coroutines-test`.
+
+---
+
+## runAnchorTest
+
+`runAnchorTest` is the entry point for all Anchor tests. Pass it the same anchor factory you use in production, then structure your test with `given`, `on`, and `verify` blocks.
+
+```kotlin
+@Test
+fun `counter increment updates state`() {
+    runAnchorTest(RememberAnchorScope::counterAnchor) {
+        given("the screen started") {
+            initialState { CounterState(count = -1) }
+        }
+
+        on("incrementing the counter", CounterAnchor::increment)
+
+        verify("the state updated with the incremented value") {
+            assertState { copy(count = 0) }
+            assertSignal { CounterSignal.Increment }
+        }
+    }
+}
+```
+
+The test uses a `AnchorTestRuntime` under the hood — a recording implementation that captures every `reduce`, `post`, `emit`, and `effect` call in order, then replays your assertions against the recording.
+
+---
+
+## Given — Setup
+
+The `given` block sets up preconditions for the test.
+
+### `initialState`
+
+Override the default initial state:
+
+```kotlin
+given("a counter that already has a value") {
+    initialState { CounterState(count = 100) }
+}
+```
+
+The lambda returns the state to start with. If omitted, the anchor factory's default `initialState` is used.
+
+### `effectScope`
+
+Provide a custom effect scope (useful for injecting test doubles):
+
+```kotlin
+given("the API returns a specific user") {
+    effectScope { MyEffect(api = FakeApi()) }
+}
+```
+
+---
+
+## On — Action
+
+The `on` block specifies which action to execute. You can pass a function reference or a lambda:
+
+```kotlin
+// Function reference
+on("incrementing the counter", CounterAnchor::increment)
+
+// Lambda (for actions with parameters)
+on("updating the text") {
+    updateText("Hello")
+}
+```
+
+---
+
+## Verify — Assertions
+
+The `verify` block asserts the outcomes of the action. Assertions must be declared **in the same order** the action produces them.
+
+### `assertState`
+
+Verifies a state reduction occurred. The lambda receives the previous state and returns the expected new state:
+
+```kotlin
+verify("the count increased") {
+    assertState { copy(count = count + 1) }
+}
+```
+
+### `assertSignal`
+
+Verifies a signal was posted:
+
+```kotlin
+verify("an increment signal was sent") {
+    assertSignal { CounterSignal.Increment }
+}
+```
+
+### `assertEvent`
+
+Verifies an internal event was emitted:
+
+```kotlin
+verify("a cancel event was emitted") {
+    assertEvent { MainEvent.Cancel }
+}
+```
+
+### `assertEffect`
+
+Verifies an effect block was executed:
+
+```kotlin
+verify("the API was called") {
+    assertEffect { api.fetchData() }
+}
+```
+
+### Ordering
+
+Assertions are matched against recorded actions **in order**. If an action calls `reduce`, then `post`, your verify block must call `assertState` before `assertSignal`:
+
+```kotlin
+// Action
+suspend fun CounterAnchor.increment() {
+    reduce { copy(count = count + 1) }    // 1st
+    post { CounterSignal.Increment }       // 2nd
+}
+
+// Test
+verify("state updated and signal posted") {
+    assertState { copy(count = 0) }        // matches 1st
+    assertSignal { CounterSignal.Increment } // matches 2nd
+}
+```
+
+---
+
+## Examples
+
+### Basic state and signal test
+
+```kotlin
+@Test
+fun `counter increment updates state`() {
+    runAnchorTest(RememberAnchorScope::counterAnchor) {
+        given("the screen started") {
+            initialState { CounterState(count = -1) }
+        }
+
+        on("incrementing the counter", CounterAnchor::increment)
+
+        verify("the state updated with the incremented value") {
+            assertState { copy(count = 0) }
+            assertSignal { CounterSignal.Increment }
+        }
+    }
+}
+```
+
+### Testing events
+
+```kotlin
+@Test
+fun `clear cancels the counting`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        given("the initial state started to count up") {
+            initialState { mainViewState().copy(hundreds = 100, iterationCounter = "100") }
+        }
+
+        on("clearing", MainAnchor::clear)
+
+        verify("cancel event emitted and state cleared") {
+            assertEvent { MainEvent.Cancel }
+            assertState { copy(details = "cleared", iterationCounter = null) }
+        }
+    }
+}
+```
+
+### Providing a custom effect scope
+
+```kotlin
+@Test
+fun `refresh triggers the subscription`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        given("the screen is ready") {
+            initialState { mainViewState() }
+            effectScope { MainEffect() }
+        }
+
+        on("refreshing", MainAnchor::refresh)
+
+        verify("refresh event emitted") {
+            assertEvent { MainEvent.Refresh }
+        }
+    }
+}
+```
+
+### Skipping the given block
+
+If you don't need custom setup, you can omit the `given` block entirely. The test will use the anchor factory's default state and effect scope:
+
+```kotlin
+@Test
+fun `sayHi sets the details`() {
+    runAnchorTest(RememberAnchorScope::mainAnchor) {
+        on("saying hi", MainAnchor::sayHi)
+
+        verify("the details are set") {
+            assertState { copy(details = "Hello Android!") }
+        }
+    }
+}
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 
 POM_GROUP_ID=dev.kioba.anchor
-POM_VERSION=0.1.0
+POM_VERSION=0.1.1
 mavenCentralHost=CENTRAL_PORTAL

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ plugins:
   - macros
 
 extra:
-  version: "0.1.1"
+  version: "0.1.0"
   group_id: "dev.kioba.anchor"
   social:
     - icon: fontawesome/brands/github-alt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ plugins:
   - macros
 
 extra:
-  version: "0.1.0"
+  version: "0.1.1"
   group_id: "dev.kioba.anchor"
   social:
     - icon: fontawesome/brands/github-alt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,10 +36,14 @@ theme:
       primary: teal
       accent: lime
 
-  plugins:
-    - social
+plugins:
+  - search
+  - social
+  - macros
 
 extra:
+  version: "0.1.0"
+  group_id: "dev.kioba.anchor"
   social:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/kioba
@@ -65,5 +69,7 @@ markdown_extensions:
 nav:
   - 'Introduction': index.md
   - 'Core Concepts': concepts.md
+  - 'Compose Integration': compose.md
+  - 'Testing': testing.md
   - 'API Reference': api.md
   - 'Examples': examples.md

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generates docs/llms-full.txt from the source documentation files.
+# MkDocs macros ({{ version }}, {{ group_id }}) are resolved to their
+# actual values from mkdocs.yml so the output is a standalone file.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUTPUT="$REPO_ROOT/docs/llms-full.txt"
+
+# Read version and group_id from mkdocs.yml (the source of truth for docs)
+VERSION=$(grep -oE 'version: "[0-9]+\.[0-9]+\.[0-9]+"' "$REPO_ROOT/mkdocs.yml" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+GROUP_ID=$(grep -oE 'group_id: "[^"]+"' "$REPO_ROOT/mkdocs.yml" | grep -oE '"[^"]*"' | tr -d '"')
+
+if [ -z "$VERSION" ] || [ -z "$GROUP_ID" ]; then
+  echo "Error: Could not read version or group_id from mkdocs.yml" >&2
+  exit 1
+fi
+
+# Helper: read a docs file, strip MkDocs-specific syntax, resolve macros
+process_doc() {
+  local file="$1"
+  sed \
+    -e "s/{{ version }}/$VERSION/g" \
+    -e "s/{{ group_id }}/$GROUP_ID/g" \
+    -e '/^\[\!\[/d' \
+    -e '/^!!! /d' \
+    -e '/^    \*\*/d' \
+    -e 's/](concepts\.md)/](https:\/\/kioba.github.io\/anchor\/concepts\/)/g' \
+    -e 's/](api\.md)/](https:\/\/kioba.github.io\/anchor\/api\/)/g' \
+    -e 's/](examples\.md)/](https:\/\/kioba.github.io\/anchor\/examples\/)/g' \
+    -e 's/](compose\.md)/](https:\/\/kioba.github.io\/anchor\/compose\/)/g' \
+    -e 's/](testing\.md)/](https:\/\/kioba.github.io\/anchor\/testing\/)/g' \
+    "$file"
+}
+
+cat > "$OUTPUT" << HEADER
+# Anchor — Complete Documentation
+
+> A lightweight, type-safe state management architecture for Kotlin Multiplatform with Jetpack Compose integration.
+
+- Repository: https://github.com/kioba/anchor
+- Published version: $VERSION
+- Group ID: $GROUP_ID
+- Artifacts: anchor, anchor-compose, anchor-test
+- Platforms: Android, iOS (iosX64, iosArm64, iosSimulatorArm64), Desktop (JVM)
+
+---
+HEADER
+
+# Concatenate docs in navigation order
+DOCS=(
+  "docs/index.md"
+  "docs/concepts.md"
+  "docs/compose.md"
+  "docs/testing.md"
+  "docs/api.md"
+  "docs/examples.md"
+)
+
+for doc in "${DOCS[@]}"; do
+  filepath="$REPO_ROOT/$doc"
+  if [ ! -f "$filepath" ]; then
+    echo "Warning: $doc not found, skipping" >&2
+    continue
+  fi
+
+  echo "" >> "$OUTPUT"
+  process_doc "$filepath" >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+  echo "---" >> "$OUTPUT"
+done
+
+# Remove trailing separator
+sed -i '' -e '$ { /^---$/d; }' "$OUTPUT" 2>/dev/null || sed -i -e '$ { /^---$/d; }' "$OUTPUT"
+
+echo "Generated $OUTPUT (version: $VERSION, group_id: $GROUP_ID)"


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the `anchor-compose` and `anchor-test` modules, introduces LLM-friendly documentation following emerging standards, fixes version misalignment, and automates version consistency.

## Changes

### Documentation pages
- **`docs/compose.md`** — New Compose Integration page (RememberAnchor, collectState, anchor(), HandleSignal, PreviewAnchor)
- **`docs/testing.md`** — New Testing page (runAnchorTest BDD DSL, given/on/verify, assertions)
- **`docs/index.md`** — Updated installation: Maven Central, all 3 modules, module summary table
- **`README.md`** — Added anchor-compose and anchor-test to installation

### LLM-friendly documentation
- **`docs/llms.txt`** — Documentation index following the [llmstxt.org](https://llmstxt.org) standard (served at `/llms.txt`)
- **`docs/llms-full.txt`** — Complete docs concatenated into a single file (served at `/llms-full.txt`)
- **`AGENTS.md`** — Universal AI coding context file (read by Cursor, Copilot, Codex, Jules, Windsurf, Devin, etc.)

### Version fixes & automation
- Fixed stale versions (`0.0.8`/`0.0.10` → `0.1.0`) and wrong groupId in docs
- Bumped `POM_VERSION` to `0.1.1` (next release); docs show `0.1.0` (last published)
- **`mkdocs.yml`** — Added macros plugin with `{{ version }}`/`{{ group_id }}` template variables; fixed plugins nesting
- **`pr_check.yml`** — New `version_check` CI job verifying doc version consistency on every PR
- **`package-publish.yml`** — Extended version bump step to auto-update README, mkdocs.yml, CLAUDE.md, AGENTS.md, llms-full.txt
- **`publish_docs.yml`** — Added `mkdocs-macros-plugin` to pip install

## Test plan

- [x] `mkdocs build` succeeds
- [x] Macros expand correctly (`{{ version }}` → `0.1.0`)
- [x] `llms.txt` and `llms-full.txt` served as static files (not nav pages)
- [ ] `version_check` CI job passes on this PR
- [ ] Review compose.md and testing.md for accuracy