### PR TITLE
✨ Add error handling API with Err type parameter and example usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ dependencies {
 
 ## Architecture
 
-The core abstraction is `Anchor<R, S>` where `R : Effect` (dependencies) and `S : ViewState` (state). It provides:
+The core abstraction is `Anchor<R, S, Err>` where `R : Effect` (dependencies), `S : ViewState` (state), and `Err : Any` (domain error type; use `Nothing` when no domain errors are needed). A `PureAnchor<R, S>` typealias is available for `Anchor<R, S, Nothing>`. It provides:
 
 - `reduce { copy(...) }` — Immutable state updates
 - `effect { dependency.call() }` — Side effects with injected dependencies
@@ -44,7 +44,7 @@ sealed interface MySignal : Signal {
 ### 2. Create anchor factory
 
 ```kotlin
-typealias MyAnchor = Anchor<MyEffect, MyState>
+typealias MyAnchor = Anchor<MyEffect, MyState, Nothing>
 
 fun RememberAnchorScope.myAnchor(): MyAnchor =
     create(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,18 +109,22 @@ See https://gitmoji.dev for the full list.
 The architecture is built on a hierarchy of capabilities provided through interfaces:
 
 ```
-Anchor<E, S>  (abstract base)
-├── StateAnchor<S>          - Read-only state access via `state: StateFlow<S>`
-├── MutableStateAnchor<S>   - State mutations via `reduce { copy(...) }`
-├── EffectAnchor<E>         - Side effect execution with effect scope
-├── CancellableAnchor<E,S>  - Cancellable task management (keyed jobs)
-├── SubscriptionAnchor      - Event emission via `emit { ... }`
-└── SignalAnchor            - One-time signals via `post { ... }`
-    └── AnchorSink<E, S>    - Combines all above capabilities
-        └── AnchorRuntime<E, S>  - Concrete implementation
+Anchor<R, S, Err>  (abstract base — R: Effect, S: ViewState, Err: domain error type)
+├── StateAnchor<S>              - Read-only state access via `state: StateFlow<S>`
+├── MutableStateAnchor<S>       - State mutations via `reduce { copy(...) }`
+├── EffectAnchor<R>             - Side effect execution with effect scope
+├── CancellableAnchor<R,S,Err>  - Cancellable task management (keyed jobs)
+├── SubscriptionAnchor          - Event emission via `emit { ... }`
+└── SignalAnchor                - One-time signals via `post { ... }`
+    └── AnchorSink<R, S, Err>   - Combines all above capabilities
+        └── AnchorRuntime<R, S, Err>  - Concrete implementation
+
+PureAnchor<R, S> = Anchor<R, S, Nothing>  (typealias for anchors without domain errors)
 ```
 
-**Implementation**: `AnchorRuntime` (`anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorRuntime.kt`) manages:
+**Note**: `AnchorScope<out R, out S>` intentionally stays at 2 type parameters — `Err` is carried on the `Anchor` receiver inside `execute`'s block only, since `raise()` would require contravariant position conflicting with `out` variance.
+
+**Implementation**: `AnchorRuntime` (`anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt`) manages:
 - State via `MutableStateFlow<S>`
 - Signals via `MutableSharedFlow<SignalProvider>` (one-time UI events)
 - Events via `MutableSharedFlow<Event>` (internal reactive stream)
@@ -128,7 +132,7 @@ Anchor<E, S>  (abstract base)
 
 ### Marker Interfaces
 
-Four empty marker interfaces provide type safety (`anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorMarkers.kt`):
+Four empty marker interfaces provide type safety (`anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt`):
 
 - `ViewState` - UI state data classes
 - `Effect` - External dependencies/side effect scope
@@ -156,11 +160,11 @@ UI Recomposition
 **Parallel flows**:
 - `post { Signal }` → `MutableSharedFlow<SignalProvider>` → `HandleSignal` → LaunchedEffect
 - `emit { Event }` → `MutableSharedFlow<Event>` → Subscription chains
-- `effect { }` → Coroutine execution with E (Effect) receiver
+- `effect { }` → Coroutine execution with R (Effect) receiver
 
 ### Compose Integration
 
-**Primary composable**: `RememberAnchor` (`anchor/src/androidMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt`)
+**Primary composable**: `RememberAnchor` (`anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt`)
 
 Responsibilities:
 1. Creates/retrieves ViewModel-scoped `AnchorRuntime` via `ContainerViewModel`
@@ -196,10 +200,10 @@ suspend fun CounterAnchor.increment() {
 onClick = anchor(CounterAnchor::increment)
 ```
 
-The `AnchorScope<E, S>` is a `fun interface` with SAM conversion:
+The `AnchorScope<R, S>` is a `fun interface` with SAM conversion (stays 2-param — no `Err`):
 ```kotlin
-fun interface AnchorScope<out E : Effect, out S : ViewState> {
-  fun execute(block: suspend Anchor<@UnsafeVariance E, @UnsafeVariance S>.() -> Unit)
+fun interface AnchorScope<out R : Effect, out S : ViewState> {
+  fun execute(block: suspend Anchor<@UnsafeVariance R, @UnsafeVariance S, *>.() -> Unit)
 }
 ```
 
@@ -252,9 +256,9 @@ runAnchorTest(RememberAnchorScope::counterAnchor) {
 ```
 
 **Test scopes**:
-- `GivenScope<E, S>` - Setup initial state, effect scope, preconditions
-- `VerifyScope<E, S>` - Assert state changes, signals, events, effects
-- `AnchorTestScope<E, S>` - Orchestrator connecting given/on/verify
+- `GivenScope<R, S>` - Setup initial state, effect scope, preconditions
+- `VerifyScope<R, S>` - Assert state changes, signals, events, effects
+- `AnchorTestScope<R, S>` - Orchestrator connecting given/on/verify
 
 **Test runtime** (`AnchorTestRuntime.kt`) records all actions (reduce, signal, emit, effect) for deterministic verification.
 
@@ -263,12 +267,20 @@ runAnchorTest(RememberAnchorScope::counterAnchor) {
 ```
 anchor/                      # Core library (publishable)
 ├── commonMain/             # Multiplatform code
-│   ├── Anchor.kt           # Interface hierarchy
-│   ├── AnchorRuntime.kt    # Concrete implementation
-│   ├── AnchorScope.kt      # UI-to-Anchor bridge
+│   ├── Anchor.kt           # Interface hierarchy (Anchor<R,S,Err>)
+│   ├── PureAnchor.kt       # Typealias PureAnchor<R,S> = Anchor<R,S,Nothing>
+│   ├── AnchorScope.kt      # UI-to-Anchor bridge (stays 2-param)
 │   ├── SubscriptionDsl.kt  # Reactive event handling
+│   ├── internal/
+│   │   ├── AnchorRuntime.kt  # Concrete implementation
+│   │   └── ContainedScope.kt # Internal scope bridge
 │   └── viewmodel/          # ViewModel integration
-└── androidMain/            # Android/Compose specific
+├── iosMain/                # iOS-specific
+│   ├── RememberAnchor.kt   # iOS anchor creation
+│   └── NativeFlows.kt      # Flow wrappers for Swift
+
+anchor-compose/              # Compose bindings (publishable)
+└── commonMain/
     └── compose/
         ├── RememberAnchor.kt    # Main composable
         ├── AnchorAction.kt      # Action creation
@@ -306,7 +318,7 @@ sealed interface MyEvent : Event {
 
 2. **Create anchor factory**:
 ```kotlin
-fun RememberAnchorScope.myAnchor(): Anchor<MyEffect, MyState> =
+fun RememberAnchorScope.myAnchor(): Anchor<MyEffect, MyState, Nothing> =
   create(
     initialState = ::MyState,
     effectScope = { MyEffect() },

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Defining a simple Counter component with Anchor:
 ```kotlin
 data class CounterState(val count: Int = 0) : ViewState
 
-typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(initialState = ::CounterState, effectScope = { EmptyEffect })

--- a/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/AnchorAction.kt
+++ b/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/AnchorAction.kt
@@ -39,7 +39,7 @@ import dev.kioba.anchor.ViewState
 public fun <A> anchor(
   block: suspend A.() -> Unit,
 ): () -> Unit
-  where A : Anchor<out Effect, out ViewState> {
+  where A : Anchor<out Effect, out ViewState, *> {
   val scope = LocalAnchor.current
   return {
     @Suppress("UNCHECKED_CAST")
@@ -82,7 +82,7 @@ public fun <A> anchor(
 public fun <A, I> anchor(
   block: suspend A.(I) -> Unit,
 ): (I) -> Unit
-  where A : Anchor<out Effect, out ViewState> {
+  where A : Anchor<out Effect, out ViewState, *> {
   val scope = LocalAnchor.current
   return { i ->
     // Safe cast: A is constrained to be an Anchor subtype, and scope is provided
@@ -126,7 +126,7 @@ public fun <A, I> anchor(
 public fun <A, I, O> anchor(
   block: suspend A.(I, O) -> Unit,
 ): (I, O) -> Unit
-  where A : Anchor<out Effect, out ViewState> {
+  where A : Anchor<out Effect, out ViewState, *> {
   val scope = LocalAnchor.current
   return { i, o ->
     // Safe cast: A is constrained to be an Anchor subtype, and scope is provided
@@ -155,7 +155,7 @@ public fun <A, I, O> anchor(
 public fun <A, I, O, T> anchor(
   block: suspend A.(I, O, T) -> Unit,
 ): (I, O, T) -> Unit
-  where A : Anchor<out Effect, out ViewState> {
+  where A : Anchor<out Effect, out ViewState, *> {
   val scope = LocalAnchor.current
   return { i, o, t ->
     // Safe cast: A is constrained to be an Anchor subtype, and scope is provided

--- a/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt
+++ b/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/RememberAnchor.kt
@@ -148,13 +148,13 @@ public fun <S : ViewState> PreviewAnchor(
 @Suppress("ModifierRequired")
 @Composable
 public inline fun <reified S, R> RememberAnchor(
-  noinline scope: @DisallowComposableCalls RememberAnchorScope.() -> Anchor<R, S>,
+  noinline scope: @DisallowComposableCalls RememberAnchorScope.() -> Anchor<R, S, *>,
   customKey: String? = null,
   crossinline content: @Composable AnchorStateScope<S>.() -> Unit,
 ) where R : Effect, S : ViewState {
   val key = customKey ?: S::class.qualifiedName.orEmpty()
 
-  val anchorScope: ContainerViewModel<R, S> =
+  val anchorScope: ContainerViewModel<R, S, *> =
     viewModel(
       key = key,
       factory = anchorContainerViewModelFactory { scope() },

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.runTest
 
 @AnchorTestDsl
 public inline fun <reified R, reified S> runAnchorTest(
-  noinline builder: RememberAnchorScope.() -> Anchor<R, S>,
+  noinline builder: RememberAnchorScope.() -> Anchor<R, S, *>,
   crossinline block: suspend AnchorTestScope<R, S>.() -> Unit,
 ): TestResult where R : Effect, S : ViewState =
   runTest {

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -15,7 +15,7 @@ internal class AnchorTestRuntime<R, S>(
   internal val effectScope: R,
   @PublishedApi
   internal val initState: S,
-) : Anchor<R, S>() where R : Effect, S : ViewState {
+) : Anchor<R, S, Nothing>() where R : Effect, S : ViewState {
 
   val verifyActions = mutableListOf<VerifyAction>()
   private var currentState = initState
@@ -37,7 +37,7 @@ internal class AnchorTestRuntime<R, S>(
 
   override suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<R, S>.() -> Unit,
+    block: suspend Anchor<R, S, Nothing>.() -> Unit,
   ) {
     block()
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertIs
 
 public class AnchorTestScope<R : Effect, S : ViewState>(
   @PublishedApi
-  internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S>,
+  internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S, *>,
 ) {
   @PublishedApi
   internal val givenScope: GivenScopeImpl<R, S> = GivenScopeImpl()
@@ -20,7 +20,7 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
   internal val verifyScope: VerifyScopeImpl<R, S> = VerifyScopeImpl()
 
   @PublishedApi
-  internal lateinit var action: suspend Anchor<R, S>.() -> Unit
+  internal lateinit var action: suspend Anchor<R, S, Nothing>.() -> Unit
 
   @AnchorTestDsl
   public inline fun given(
@@ -32,7 +32,7 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
   @AnchorTestDsl
   public fun on(
     @Suppress("UNUSED_PARAMETER") description: String,
-    anchorOf: suspend Anchor<R, S>.() -> Unit,
+    anchorOf: suspend Anchor<R, S, Nothing>.() -> Unit,
   ) {
     action = anchorOf
   }
@@ -48,19 +48,22 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
 
 @PublishedApi
 internal suspend inline fun <reified R : Effect, reified S : ViewState> AnchorTestScope<R, S>.assert() {
-  val rememberAnchorScope = object : RememberAnchorScope {
-    @Suppress("UNCHECKED_CAST")
-    override fun <R : Effect, S : ViewState> create(
-      effectScope: () -> R,
-      initialState: () -> S,
-      init: (suspend Anchor<R, S>.() -> Unit)?,
-      subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)?
-    ): Anchor<R, S> =
-      AnchorTestRuntime(
-        givenScope.effectScope as? R ?: effectScope(),
-        givenScope.initState as? S ?: initialState(),
-      )
-  }
+  val rememberAnchorScope =
+    object : RememberAnchorScope {
+      @Suppress("UNCHECKED_CAST")
+      override fun <R : Effect, S : ViewState, Err : Any> create(
+        effectScope: () -> R,
+        initialState: () -> S,
+        init: (suspend Anchor<R, S, Err>.() -> Unit)?,
+        onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)?,
+        defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)?,
+        subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)?,
+      ): Anchor<R, S, Err> =
+        AnchorTestRuntime(
+          givenScope.effectScope as? R ?: effectScope(),
+          givenScope.initState as? S ?: initialState(),
+        ) as Anchor<R, S, Err>
+    }
   val anchor: AnchorTestRuntime<R, S> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S>
 
   anchor.action()

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
@@ -70,11 +70,13 @@ public fun interface SignalProvider {
  *
  * @param R The [Effect] type.
  * @param S The [ViewState] type.
+ * @param Err The domain error type.
  */
-public abstract class AnchorSink<R, S> : Anchor<R, S>()
+public abstract class AnchorSink<R, S, Err> : Anchor<R, S, Err>()
   where
         R : Effect,
-        S : ViewState {
+        S : ViewState,
+        Err : Any {
   /**
    * The current state as a [StateFlow].
    */
@@ -94,17 +96,19 @@ public abstract class AnchorSink<R, S> : Anchor<R, S>()
  *
  * @param R The [Effect] type providing dependencies for side effects.
  * @param S The [ViewState] type representing the UI state.
+ * @param Err The domain error type. Use [Nothing] when no domain errors are needed.
  */
 @AnchorDsl
-public abstract class Anchor<R, S> :
+public abstract class Anchor<R, S, Err> :
   MutableStateAnchor<S>,
   EffectAnchor<R>,
-  CancellableAnchor<R, S>,
+  CancellableAnchor<R, S, Err>,
   SubscriptionAnchor,
   SignalAnchor
   where
         R : Effect,
-        S : ViewState
+        S : ViewState,
+        Err : Any
 
 /**
  * Provides access to the current state.
@@ -186,9 +190,10 @@ public interface EffectAnchor<R> where R : Effect {
  *
  * @param R The [Effect] type.
  * @param S The [ViewState] type.
+ * @param Err The domain error type.
  */
 @AnchorDsl
-public interface CancellableAnchor<R, S> where R : Effect, S : ViewState {
+public interface CancellableAnchor<R, S, Err> where R : Effect, S : ViewState, Err : Any {
   /**
    * Executes a block that can be cancelled by its [key].
    *
@@ -208,7 +213,7 @@ public interface CancellableAnchor<R, S> where R : Effect, S : ViewState {
   @AnchorDsl
   public suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<R, S>.() -> Unit,
+    block: suspend Anchor<R, S, Err>.() -> Unit,
   )
 }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorScope.kt
@@ -34,7 +34,7 @@ public fun interface AnchorScope<out R : Effect, out S : ViewState> {
    * @param block The action to execute with the Anchor as receiver
    */
   public fun execute(
-    block: suspend Anchor<@UnsafeVariance R, @UnsafeVariance S>.() -> Unit,
+    block: suspend Anchor<@UnsafeVariance R, @UnsafeVariance S, *>.() -> Unit,
   )
 }
 
@@ -52,11 +52,11 @@ public fun interface AnchorScope<out R : Effect, out S : ViewState> {
  */
 @PublishedApi
 internal fun <R : Effect, S : ViewState> AnchorScope(
-  containedScope: ContainedScope<out Anchor<R, S>, R, S>,
+  containedScope: ContainedScope<out Anchor<R, S, *>, R, S, *>,
 ): AnchorScope<R, S> =
   AnchorScope { block ->
-    // Safe cast: block with receiver Anchor<R, S> can be called on any Anchor<*, *>
-    // because Anchor<R, S> is a subtype of Anchor<*, *>
+    // Safe cast: block with receiver Anchor<R, S, *> can be called on any Anchor<*, *, *>
+    // because Anchor<R, S, *> is a subtype of Anchor<*, *, *>
     @Suppress("UNCHECKED_CAST")
-    containedScope.execute(block as suspend Anchor<*, *>.() -> Unit)
+    containedScope.execute(block as suspend Anchor<*, *, *>.() -> Unit)
   }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/PureAnchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/PureAnchor.kt
@@ -1,0 +1,11 @@
+package dev.kioba.anchor
+
+/**
+ * A convenience typealias for [Anchor] instances that have no domain error type.
+ *
+ * Use this when your anchor does not raise domain-level errors.
+ *
+ * @param R The [Effect] type providing dependencies for side effects.
+ * @param S The [ViewState] type representing the UI state.
+ */
+public typealias PureAnchor<R, S> = Anchor<R, S, Nothing>

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/RememberAnchorScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/RememberAnchorScope.kt
@@ -13,10 +13,13 @@ public interface RememberAnchorScope {
    *
    * @param R The [Effect] type.
    * @param S The [ViewState] type.
+   * @param Err The domain error type. Use [Nothing] when no domain errors are needed.
    * @param effectScope A factory function for the [Effect] dependencies.
    * @param initialState A factory function for the initial [ViewState].
    * @param init An optional initialization block executed once when the Anchor is created.
    * @param subscriptions An optional block for setting up event subscriptions.
+   * @param onDomainError An optional callback invoked when a domain error is raised.
+   * @param defect An optional callback invoked when an unexpected error occurs.
    * @return A new [Anchor] instance.
    *
    * Example:
@@ -30,28 +33,34 @@ public interface RememberAnchorScope {
    *   )
    * ```
    */
-  public fun <R, S> create(
+  public fun <R, S, Err> create(
     effectScope: () -> R,
     initialState: () -> S,
-    init: (suspend Anchor<R, S>.() -> Unit)? = null,
-    subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)? = null,
-  ): Anchor<R, S> where R : Effect, S : ViewState
+    init: (suspend Anchor<R, S, Err>.() -> Unit)? = null,
+    onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
+    defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null,
+    subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)? = null,
+  ): Anchor<R, S, Err> where R : Effect, S : ViewState, Err : Any
 }
 
 /**
  * Default implementation of [RememberAnchorScope] that uses [AnchorRuntime].
  */
-public object AnchorRuntimeScope : RememberAnchorScope {
-  override fun <R : Effect, S : ViewState> create(
+internal object AnchorRuntimeScope : RememberAnchorScope {
+  override fun <R : Effect, S : ViewState, Err : Any> create(
     effectScope: () -> R,
     initialState: () -> S,
-    init: (suspend Anchor<R, S>.() -> Unit)?,
-    subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)?,
-  ): Anchor<R, S> =
+    init: (suspend Anchor<R, S, Err>.() -> Unit)?,
+    onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)?,
+    defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)?,
+    subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)?,
+  ): Anchor<R, S, Err> =
     AnchorRuntime(
       initialState = initialState,
       effectScope = effectScope,
       init = init,
       subscriptions = subscriptions,
+      onDomainError = onDomainError,
+      defect = defect,
     )
 }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
@@ -11,20 +11,21 @@ import kotlinx.coroutines.flow.onEach
  *
  * @param R The [Effect] type.
  * @param S The [ViewState] type.
+ * @param Err The domain error type.
  */
 @AnchorDsl
-public class SubscriptionsScope<R, S>(
+public class SubscriptionsScope<R, S, Err>(
   @PublishedApi
   internal val chain: Flow<Event>,
   @PublishedApi
-  internal val anchor: Anchor<R, S>,
+  internal val anchor: Anchor<R, S, Err>,
   /**
    * The [Effect] dependencies available in this scope.
    */
   public val effect: R,
   @PublishedApi
   internal val flows: MutableList<Flow<*>> = mutableListOf(),
-) where R : Effect, S : ViewState {
+) where R : Effect, S : ViewState, Err : Any {
 
   /**
    * Extension function to execute an action on the [Anchor] for each value emitted by a [Flow].
@@ -35,7 +36,7 @@ public class SubscriptionsScope<R, S>(
    */
   @AnchorDsl
   public fun <I> Flow<I>.anchor(
-    effect: Anchor<R, S>.(I) -> Unit,
+    effect: Anchor<R, S, Err>.(I) -> Unit,
   ): Flow<I> =
     onEach { value -> anchor.effect(value) }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
@@ -33,15 +33,18 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi
-internal class AnchorRuntime<R, S>(
+internal class AnchorRuntime<R, S, Err>(
   val initialState: () -> S,
   val effectScope: () -> R,
-  internal val init: (suspend Anchor<R, S>.() -> Unit)? = null,
-  internal val subscriptions: (suspend SubscriptionsScope<R, S>.() -> Unit)? = null,
-) : AnchorSink<R, S>()
+  internal val init: (suspend Anchor<R, S, Err>.() -> Unit)? = null,
+  internal val subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)? = null,
+  internal val onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
+  internal val defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null,
+) : AnchorSink<R, S, Err>()
   where
         R : Effect,
-        S : ViewState {
+        S : ViewState,
+        Err : Any {
   @PublishedApi
   @Suppress("ktlint:standard:backing-property-naming", "PropertyName")
   internal val _viewState: MutableStateFlow<S> = MutableStateFlow(initialState())
@@ -84,7 +87,7 @@ internal class AnchorRuntime<R, S>(
   }
 
   private suspend fun <T : Event> SharedFlow<T>.handlers(): Flow<Any?> =
-    SubscriptionsScope(this, anchor = this@AnchorRuntime, effect = effect)
+    SubscriptionsScope<R, S, Err>(this, anchor = this@AnchorRuntime, effect = effect)
       .also { scope -> subscriptions?.invoke(scope) }
       .flows
       .merge()
@@ -134,7 +137,7 @@ internal class AnchorRuntime<R, S>(
    */
   override suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<R, S>.() -> Unit,
+    block: suspend Anchor<R, S, Err>.() -> Unit,
   ) {
     coroutineScope {
       val jobToWait =

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ContainedScope.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ContainedScope.kt
@@ -8,18 +8,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @PublishedApi
-internal interface ContainedScope<A, R, S>
+internal interface ContainedScope<A, R, S, Err>
   where
-A : Anchor<R, S>,
+A : Anchor<R, S, Err>,
 R : Effect,
-S : ViewState {
+S : ViewState,
+Err : Any {
   val anchor: A
   val coroutineScope: CoroutineScope
 }
 
 @PublishedApi
-internal fun <A, R, S> ContainedScope<A, R, S>.execute(
-  block: suspend Anchor<*, *>.() -> Unit,
-) where A : Anchor<R, S>, R : Effect, S : ViewState {
+internal fun <A, R, S, Err> ContainedScope<A, R, S, Err>.execute(
+  block: suspend Anchor<*, *, *>.() -> Unit,
+) where A : Anchor<R, S, Err>, R : Effect, S : ViewState, Err : Any {
   coroutineScope.launch(Dispatchers.Default) { anchor.block() }
 }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
@@ -8,29 +8,40 @@ import dev.kioba.anchor.Effect
 import dev.kioba.anchor.SignalProvider
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.internal.AnchorRuntime
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-public class ContainerViewModel<R, S> @PublishedApi internal constructor(
-  internal val anchor: AnchorRuntime<R, S>,
-) : ViewModel(),
-  AnchorScope<R, S>
+public class ContainerViewModel<R, S, Err>
+  @PublishedApi
+  internal constructor(
+    internal val anchor: AnchorRuntime<R, S, Err>,
+  ) : ViewModel(),
+    AnchorScope<R, S>
   where
         R : Effect,
-        S : ViewState {
-
+        S : ViewState,
+        Err : Any {
   public val viewState: StateFlow<S>
     get() = anchor.viewState
 
   public val signals: Flow<SignalProvider>
     get() = anchor.signals
 
-  override fun execute(block: suspend Anchor<R, S>.() -> Unit) {
+  override fun execute(
+    block: suspend Anchor<R, S, *>.() -> Unit,
+  ) {
     viewModelScope.launch(Dispatchers.Default) {
-      @Suppress("UNCHECKED_CAST")
-      anchor.block()
+      try {
+        @Suppress("UNCHECKED_CAST")
+        anchor.block()
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Throwable) {
+        anchor.defect?.invoke(anchor, e) ?: throw e
+      }
     }
   }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ViewModelProvider.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ViewModelProvider.kt
@@ -8,12 +8,12 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.internal.AnchorRuntime
 
 @PublishedApi
-internal fun <R, A, S> containerViewModelFactory(
+internal fun <R, A, S, Err> containerViewModelFactory(
   factory: () -> A
-): ContainerViewModelFactory where R : Effect, A : AnchorRuntime<R, S>, S : ViewState =
+): ContainerViewModelFactory where R : Effect, A : AnchorRuntime<R, S, Err>, S : ViewState, Err : Any =
   ContainerViewModelFactory { ContainerViewModel(factory()) }
 
 public fun <R : Effect, S : ViewState> anchorContainerViewModelFactory(
-  scope: RememberAnchorScope.() -> Anchor<R, S>,
+  scope: RememberAnchorScope.() -> Anchor<R, S, *>,
 ): ContainerViewModelFactory =
-  containerViewModelFactory { AnchorRuntimeScope.scope() as AnchorRuntime<R, S> }
+  containerViewModelFactory { AnchorRuntimeScope.scope() as AnchorRuntime<R, S, *> }

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/CancellableBasicTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/CancellableBasicTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
  */
 class CancellableBasicTest {
 
-  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState> {
+  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState, Nothing> {
     return AnchorRuntime(
       initialState = { TestState(value = 0) },
       effectScope = { EmptyEffect },

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/CancellableTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/CancellableTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertTrue
  * 4. Edge cases - multiple keys, rapid calls, exceptions, etc.
  */
 class CancellableTest {
-  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState> =
+  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState, Nothing> =
     AnchorRuntime(
       initialState = { TestState(value = 0) },
       effectScope = { EmptyEffect },

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/JobIdentityEdgeCaseTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/JobIdentityEdgeCaseTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
  * Tests edge cases where job identity comparison might behave unexpectedly.
  */
 class JobIdentityEdgeCaseTest {
-  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState> =
+  private fun createTestAnchor(): AnchorRuntime<EmptyEffect, TestState, Nothing> =
     AnchorRuntime(
       initialState = { TestState(value = 0) },
       effectScope = { EmptyEffect },

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/JobIdentityTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/JobIdentityTest.kt
@@ -51,7 +51,7 @@ class JobIdentityTest {
   fun `verify cleanup identity check in cancellable pattern`() =
     runBlocking {
       val anchor =
-        AnchorRuntime<EmptyEffect, TestState>(
+        AnchorRuntime<EmptyEffect, TestState, Nothing>(
           initialState = { TestState(value = 0) },
           effectScope = { EmptyEffect },
           init = null,

--- a/anchor/src/iosMain/kotlin/dev/kioba/anchor/RememberAnchor.kt
+++ b/anchor/src/iosMain/kotlin/dev/kioba/anchor/RememberAnchor.kt
@@ -21,21 +21,21 @@ import dev.kioba.anchor.viewmodel.containerViewModelFactory
  */
 @Suppress("UNCHECKED_CAST")
 public fun <S, E> rememberAnchor(
-  scope: (RememberAnchorScope) -> Anchor<E, S>,
+  scope: (RememberAnchorScope) -> Anchor<E, S, *>,
   customKey: String? = null,
-): Anchor<E, S>
+): Anchor<E, S, *>
   where
   E : Effect,
   S : ViewState {
   val storeOwner = object : ViewModelStoreOwner {
     override val viewModelStore = ViewModelStore()
   }
-  val factory = containerViewModelFactory { scope(AnchorRuntimeScope) as AnchorRuntime<E, S> }
+  val factory = containerViewModelFactory { scope(AnchorRuntimeScope) as AnchorRuntime<E, S, *> }
   val provider = ViewModelProvider.create(storeOwner, factory)
   val anchorScope = when {
     customKey != null -> provider[customKey, ContainerViewModel::class]
     else -> provider[ContainerViewModel::class]
-  } as ContainerViewModel<E, S>
+  } as ContainerViewModel<E, S, *>
 
   return anchorScope.anchor
 }
@@ -45,7 +45,7 @@ public fun <S, E> rememberAnchor(
  *
  * Use this from iOS to collect state updates via callbacks.
  */
-public fun <R : Effect, S : ViewState> AnchorSink<R, S>.nativeViewState(): NativeStateFlow<S> =
+public fun <R : Effect, S : ViewState> AnchorSink<R, S, *>.nativeViewState(): NativeStateFlow<S> =
   NativeStateFlow(viewState)
 
 /**
@@ -53,5 +53,5 @@ public fun <R : Effect, S : ViewState> AnchorSink<R, S>.nativeViewState(): Nativ
  *
  * Use this from iOS to collect signal emissions via callbacks.
  */
-public fun <R : Effect, S : ViewState> AnchorSink<R, S>.nativeSignals(): NativeSharedFlow<SignalProvider> =
+public fun <R : Effect, S : ViewState> AnchorSink<R, S, *>.nativeSignals(): NativeSharedFlow<SignalProvider> =
   NativeSharedFlow(signals)

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,16 +4,20 @@ This page provides a detailed reference for the public API of the Anchor library
 
 ## Core API
 
-### `Anchor<E, S>`
+### `Anchor<R, S, Err>`
 
-The main interface for state management.
+The main abstract class for state management. `R` is the Effect type, `S` is the ViewState type, and `Err` is the domain error type (use `Nothing` when no domain errors are needed).
 
 - `state: S`: The current state.
 - `reduce(reducer: S.() -> S)`: Updates the state.
-- `effect(coroutineContext, block: suspend E.() -> R): R`: Executes a side effect.
+- `effect(coroutineContext, block: suspend R.() -> T): T`: Executes a side effect.
 - `cancellable(key, block)`: Executes a block that can be cancelled by a key.
 - `post(block: SignalScope.() -> Signal)`: Posts a signal to the UI.
 - `emit(block: SubscriptionScope.() -> Event)`: Emits an internal event.
+
+### `PureAnchor<R, S>`
+
+A convenience typealias for `Anchor<R, S, Nothing>` — use when your anchor has no domain errors.
 
 ---
 
@@ -25,6 +29,8 @@ Creates an `Anchor` instance.
 - `effectScope`: Factory for effect dependencies.
 - `init`: Optional initialization block.
 - `subscriptions`: Optional subscription setup block.
+- `onDomainError`: Optional callback invoked when a domain error is raised (defaults to `null`).
+- `defect`: Optional callback invoked when an unexpected error occurs (defaults to `null`).
 
 ---
 

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -160,7 +160,7 @@ sealed interface CounterSignal : Signal {
 }
 
 // Anchor factory
-typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(initialState = ::CounterState, effectScope = { EmptyEffect })

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -22,7 +22,7 @@ sealed interface CounterSignal : Signal {
 ```kotlin
 class CounterEffect : Effect
 
-typealias CounterAnchor = Anchor<CounterEffect, CounterState>
+typealias CounterAnchor = Anchor<CounterEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Here's a simple counter example to get you started:
 data class CounterState(val count: Int = 0) : ViewState
 
 // 2. Define your Anchor
-typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(initialState = ::CounterState, effectScope = { EmptyEffect })

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -52,7 +52,7 @@ Here's a simple counter example to get you started:
 data class CounterState(val count: Int = 0) : ViewState
 
 // 2. Define your Anchor
-typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(initialState = ::CounterState, effectScope = { EmptyEffect })
@@ -358,7 +358,7 @@ sealed interface CounterSignal : Signal {
 }
 
 // Anchor factory
-typealias CounterAnchor = Anchor<EmptyEffect, CounterState>
+typealias CounterAnchor = Anchor<EmptyEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(initialState = ::CounterState, effectScope = { EmptyEffect })
@@ -651,16 +651,20 @@ This page provides a detailed reference for the public API of the Anchor library
 
 ## Core API
 
-### `Anchor<E, S>`
+### `Anchor<R, S, Err>`
 
-The main interface for state management.
+The main abstract class for state management. `R` is the Effect type, `S` is the ViewState type, and `Err` is the domain error type (use `Nothing` when no domain errors are needed).
 
 - `state: S`: The current state.
 - `reduce(reducer: S.() -> S)`: Updates the state.
-- `effect(coroutineContext, block: suspend E.() -> R): R`: Executes a side effect.
+- `effect(coroutineContext, block: suspend R.() -> T): T`: Executes a side effect.
 - `cancellable(key, block)`: Executes a block that can be cancelled by a key.
 - `post(block: SignalScope.() -> Signal)`: Posts a signal to the UI.
 - `emit(block: SubscriptionScope.() -> Event)`: Emits an internal event.
+
+### `PureAnchor<R, S>`
+
+A convenience typealias for `Anchor<R, S, Nothing>` — use when your anchor has no domain errors.
 
 ---
 
@@ -672,6 +676,8 @@ Creates an `Anchor` instance.
 - `effectScope`: Factory for effect dependencies.
 - `init`: Optional initialization block.
 - `subscriptions`: Optional subscription setup block.
+- `onDomainError`: Optional callback invoked when a domain error is raised (defaults to `null`).
+- `defect`: Optional callback invoked when an unexpected error occurs (defaults to `null`).
 
 ---
 
@@ -758,7 +764,7 @@ sealed interface CounterSignal : Signal {
 ```kotlin
 class CounterEffect : Effect
 
-typealias CounterAnchor = Anchor<CounterEffect, CounterState>
+typealias CounterAnchor = Anchor<CounterEffect, CounterState, Nothing>
 
 fun RememberAnchorScope.counterAnchor(): CounterAnchor =
     create(

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,6 +4,8 @@
 
 Anchor uses Unidirectional Data Flow (UDF) with immutable state, receiver-based DSLs, and Flow-based reactivity. It targets Android, iOS (via iosX64, iosArm64, iosSimulatorArm64), and Desktop (JVM).
 
+The core type is `Anchor<R, S, Err>` where `R : Effect` (dependencies), `S : ViewState` (state), and `Err : Any` (domain error type). Use `Nothing` as `Err` when no domain errors are needed, or the `PureAnchor<R, S>` typealias.
+
 ## Docs
 
 - [Introduction](https://kioba.github.io/anchor/): Installation, quick start, and feature overview

--- a/features/config/src/commonMain/kotlin/dev/kioba/anchor/features/counter/data/ConfigAnchor.kt
+++ b/features/config/src/commonMain/kotlin/dev/kioba/anchor/features/counter/data/ConfigAnchor.kt
@@ -6,7 +6,7 @@ import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.features.counter.model.ConfigState
 
 public class ConfigEffect(): Effect
-internal typealias ConfigAnchor = Anchor<ConfigEffect, ConfigState>
+internal typealias ConfigAnchor = Anchor<ConfigEffect, ConfigState, Nothing>
 
 public fun RememberAnchorScope.configAnchor(): ConfigAnchor =
   create(

--- a/features/counter/src/commonMain/kotlin/dev/kioba/anchor/features/counter/data/CounterAnchor.kt
+++ b/features/counter/src/commonMain/kotlin/dev/kioba/anchor/features/counter/data/CounterAnchor.kt
@@ -6,7 +6,7 @@ import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.ViewState
 
 public class CounterEffect : Effect
-public typealias CounterAnchor = Anchor<CounterEffect, CounterState>
+public typealias CounterAnchor = Anchor<CounterEffect, CounterState, Nothing>
 
 public data class CounterState(
   val count: Int = 0,

--- a/features/main/src/androidMain/kotlin/dev/kioba/anchor/features/main/ui/HomePage.kt
+++ b/features/main/src/androidMain/kotlin/dev/kioba/anchor/features/main/ui/HomePage.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,7 +16,10 @@ import androidx.compose.ui.unit.dp
 import dev.kioba.anchor.compose.anchor
 import dev.kioba.anchor.features.main.data.MainAnchor
 import dev.kioba.anchor.features.main.data.clear
+import dev.kioba.anchor.features.main.data.dismissErrorDialog
 import dev.kioba.anchor.features.main.data.refresh
+import dev.kioba.anchor.features.main.data.triggerLocalError
+import dev.kioba.anchor.features.main.data.triggerPropagatedError
 import dev.kioba.anchor.features.main.model.MainViewState
 
 @Composable
@@ -40,6 +44,9 @@ internal fun HomePage(
     }
     RefreshButton()
     CancelButton()
+    LocalErrorButton()
+    PropagatedErrorButton()
+    ErrorDialog(state)
   }
 }
 
@@ -59,4 +66,37 @@ private fun RefreshButton() {
   ) {
     Text(text = "refresh")
   }
+}
+
+@Composable
+private fun LocalErrorButton() {
+  Button(
+    onClick = anchor(MainAnchor::triggerLocalError),
+  ) {
+    Text(text = "local error")
+  }
+}
+
+@Composable
+private fun PropagatedErrorButton() {
+  Button(
+    onClick = anchor(MainAnchor::triggerPropagatedError),
+  ) {
+    Text(text = "propagated error")
+  }
+}
+
+@Composable
+private fun ErrorDialog(state: MainViewState) {
+  val errorMessage = state.errorDialog ?: return
+  AlertDialog(
+    onDismissRequest = anchor(MainAnchor::dismissErrorDialog),
+    title = { Text(text = "Error") },
+    text = { Text(text = errorMessage) },
+    confirmButton = {
+      Button(onClick = anchor(MainAnchor::dismissErrorDialog)) {
+        Text(text = "OK")
+      }
+    },
+  )
 }

--- a/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainAnchor.kt
+++ b/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainAnchor.kt
@@ -6,8 +6,8 @@ import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.features.main.model.MainViewState
 
-public typealias MainAnchor = Anchor<MainEffect, MainViewState>
-public typealias MainSubScope = SubscriptionsScope<MainEffect, MainViewState>
+public typealias MainAnchor = Anchor<MainEffect, MainViewState, Nothing>
+public typealias MainSubScope = SubscriptionsScope<MainEffect, MainViewState, Nothing>
 
 public class MainEffect : Effect
 
@@ -23,4 +23,6 @@ public fun RememberAnchorScope.mainAnchor(): MainAnchor =
     effectScope = { MainEffect() },
     init = MainAnchor::sayHi,
     subscriptions = MainSubScope::subscriptions,
+    defect = MainAnchor::defect,
+    onDomainError = MainAnchor::onError,
   )

--- a/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainEffects.kt
+++ b/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainEffects.kt
@@ -3,6 +3,25 @@ package dev.kioba.anchor.features.main.data
 import dev.kioba.anchor.features.main.model.MainEvent
 import kotlinx.coroutines.delay
 
+internal fun MainAnchor.onError(
+  n: Nothing,
+) {
+  TODO()
+}
+
+internal fun MainAnchor.defect(
+  throwable: Throwable,
+) {
+  reduce {
+    copy(
+      errorDialog =
+        """A propagated error occurred:
+    |${throwable.message.orEmpty()}
+        """.trimMargin(),
+    )
+  }
+}
+
 public suspend fun MainAnchor.sayHi() {
   cancellable("Initial") {
     reduce { copy(details = "Hello Android!") }
@@ -42,6 +61,28 @@ public fun MainAnchor.iterationCounter(
 
 public fun MainAnchor.hundreds(): Int =
   withState { hundreds }
+
+public suspend fun MainAnchor.triggerLocalError() {
+  try {
+    effect { failingEffect() }
+  } catch (
+    @Suppress("TooGenericExceptionCaught") e: Exception,
+  ) {
+    reduce { copy(errorDialog = "A locally caught error occurred.") }
+  }
+}
+
+public suspend fun MainAnchor.triggerPropagatedError() {
+  effect { failingEffect() }
+}
+
+public fun MainAnchor.dismissErrorDialog() {
+  reduce { copy(errorDialog = null) }
+}
+
+@Suppress("UnusedReceiverParameter")
+public suspend fun MainEffect.failingEffect(): Nothing =
+  throw RuntimeException("Example error from effect")
 
 @Suppress("UnusedReceiverParameter")
 public suspend fun MainEffect.delayWithEffect(): Int =

--- a/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/model/MainViewState.kt
+++ b/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/model/MainViewState.kt
@@ -8,6 +8,7 @@ public data class MainViewState(
   val hundreds: Int = 0,
   val iterationCounter: String? = null,
   val selectedTab: MainTab = MainTab.Home,
+  val errorDialog: String? = null,
 ) : ViewState
 
 public sealed class MainTab {

--- a/iosApp/iosApp/ConfigView.swift
+++ b/iosApp/iosApp/ConfigView.swift
@@ -11,7 +11,7 @@ struct ConfigView: View {
 
 struct ConfigUi: View {
   @Binding var state: ConfigState
-  @Binding var anchor: AnchorAction<shared.Anchor<ConfigEffect, ConfigState>>
+  @Binding var anchor: AnchorAction<shared.Anchor<ConfigEffect, ConfigState, KotlinNothing>>
 
   @State var text: String = ""
   var body: some View {

--- a/iosApp/iosApp/CounterView.swift
+++ b/iosApp/iosApp/CounterView.swift
@@ -16,7 +16,7 @@ struct CounterView: View {
 struct CounterUi: View {
   @Binding var state: CounterState
   @Binding var signals: SwiftSignalProvider
-  @Binding var anchor: AnchorAction<shared.Anchor<CounterEffect, CounterState>>
+  @Binding var anchor: AnchorAction<shared.Anchor<CounterEffect, CounterState, KotlinNothing>>
 
   @State var animatePlus: Bool = false
   @State var animateMinus: Bool = false
@@ -85,7 +85,7 @@ struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
     @State var previewState: CounterState = CounterState.init(count: 12)
     @State var previewSignal: SwiftSignalProvider = SwiftSignalProvider(signal: UnitSignal())
-    @State var previewAnchor: AnchorAction<shared.Anchor<CounterEffect, CounterState>> = { _ in }
+    @State var previewAnchor: AnchorAction<shared.Anchor<CounterEffect, CounterState, KotlinNothing>> = { _ in }
 
     CounterUi(state: $previewState, signals: $previewSignal, anchor: $previewAnchor)
   }

--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -11,7 +11,7 @@ struct HomeView: View {
 
 struct HomeUi: View {
   @Binding var state: MainViewState
-  @Binding var anchor: AnchorAction<shared.Anchor<MainEffect, MainViewState>>
+  @Binding var anchor: AnchorAction<shared.Anchor<MainEffect, MainViewState, KotlinNothing>>
 
   @State var counter: String? = nil
 
@@ -30,7 +30,25 @@ struct HomeUi: View {
         Button("cancel") { anchor { a in try await a.clear() } }
         .buttonStyle(.borderedProminent)
         .cornerRadius(10)
-      }.onChange(of: state.iterationCounter) { counter in
+        Button("local error") { anchor { a in try await a.triggerLocalError() } }
+        .buttonStyle(.borderedProminent)
+        .cornerRadius(10)
+        Button("propagated error") { anchor { a in try await a.triggerPropagatedError() } }
+        .buttonStyle(.borderedProminent)
+        .cornerRadius(10)
+      }
+      .alert(
+        "Error",
+        isPresented: Binding(
+          get: { state.errorDialog != nil },
+          set: { if !$0 { anchor { a in a.dismissErrorDialog() } } }
+        )
+      ) {
+        Button("OK") { anchor { a in a.dismissErrorDialog() } }
+      } message: {
+        Text(state.errorDialog ?? "")
+      }
+      .onChange(of: state.iterationCounter) { counter in
         withAnimation {
           self.counter = counter
         }

--- a/iosApp/iosApp/ViewModelProtocol.swift
+++ b/iosApp/iosApp/ViewModelProtocol.swift
@@ -22,26 +22,26 @@ class SwiftSignalProvider: SignalProvider {
 }
 
 final class ViewModel<E, S>: ObservableObject where E: Effect, S: ViewState {
-  let anchorInstance: shared.Anchor<E, S>
-  var anchor: AnchorAction<shared.Anchor<E, S>>
+  let anchorInstance: shared.Anchor<E, S, KotlinNothing>
+  var anchor: AnchorAction<shared.Anchor<E, S, KotlinNothing>>
   @Published var state: S
   @Published var signal: SwiftSignalProvider
 
   private var stateCollector: NativeCancellable?
   private var signalCollector: NativeCancellable?
 
-  init(factory: @escaping (any RememberAnchorScope) -> shared.Anchor<E, S>) {
+  init(factory: @escaping (any RememberAnchorScope) -> shared.Anchor<E, S, KotlinNothing>) {
     let localAnchor = RememberAnchorKt.rememberAnchor(
-      scope: { scope in factory(scope) as! shared.Anchor<any Effect, any ViewState> },
+      scope: { scope in factory(scope) as! shared.Anchor<any Effect, any ViewState, AnyObject> },
       customKey: nil
-    ) as! shared.Anchor<E, S>
+    ) as! shared.Anchor<E, S, KotlinNothing>
 
     self.anchorInstance = localAnchor
     self.anchor = { action in Task { try await action(localAnchor) } }
     self.state = localAnchor.state as! S
     self.signal = SwiftSignalProvider(signal: UnitSignal())
 
-    let sink = localAnchor as! shared.AnchorSink<E, S>
+    let sink = localAnchor as! shared.AnchorSink<E, S, KotlinNothing>
 
     self.stateCollector = sink.nativeViewState().collect { [weak self] value in
       self?.state = value as! S


### PR DESCRIPTION
## Summary

Introduces a third generic type parameter `Err` to the `Anchor` class hierarchy, enabling type-safe domain error handling alongside the existing state management and side-effect patterns. Includes example usage on the Home Screen demonstrating both local and propagated error handling.

## API Changes

### `Err` type parameter on `Anchor<R, S, Err>`

Every interface in the Anchor hierarchy now carries an `Err : Any` type parameter for domain-specific errors:

```kotlin
abstract class Anchor<R, S, Err> :
  MutableStateAnchor<S>,
  EffectAnchor<R>,
  CancellableAnchor<R, S, Err>,
  SubscriptionAnchor,
  SignalAnchor
  where R : Effect, S : ViewState, Err : Any
```

Use `Nothing` when no domain errors are needed. A convenience typealias is provided:

```kotlin
typealias PureAnchor<R, S> = Anchor<R, S, Nothing>
```

### `onDomainError` and `defect` callbacks on `create()`

`RememberAnchorScope.create()` now accepts two optional error handlers as **Anchor receiver functions** — the same pattern used by `init`:

```kotlin
fun <R, S, Err> create(
  effectScope: () -> R,
  initialState: () -> S,
  init: (suspend Anchor<R, S, Err>.() -> Unit)? = null,
  onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
  defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null,
  subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)? = null,
): Anchor<R, S, Err>
```

**Why Anchor receiver?** Both callbacks receive the Anchor as `this`, so they can call `reduce`, `post`, `effect`, and all other Anchor DSL functions directly — no external references or workarounds needed.

- **`onDomainError`**: Invoked when a typed domain error is raised (e.g., network failure, validation error)
- **`defect`**: Invoked when an unhandled `Throwable` escapes an action — the top-level safety net

### `ContainerViewModel.execute` error routing

The ViewModel's `execute` method now catches unhandled exceptions from actions and routes them to the `defect` callback:

```kotlin
override fun execute(block: suspend Anchor<R, S, *>.() -> Unit) {
  viewModelScope.launch(Dispatchers.Default) {
    try {
      anchor.block()
    } catch (e: CancellationException) {
      throw e  // preserve structured concurrency
    } catch (e: Throwable) {
      anchor.defect?.invoke(anchor, e) ?: throw e
    }
  }
}
```

If no `defect` callback is registered, the exception is re-thrown (preserving existing behavior).

## Example: Error handling on Home Screen

### Define error handlers as named functions (same pattern as `init`)

```kotlin
internal fun MainAnchor.onError(n: Nothing) {
  TODO()
}

internal fun MainAnchor.defect(throwable: Throwable) {
  reduce {
    copy(errorDialog = "A propagated error occurred:\n${throwable.message.orEmpty()}")
  }
}
```

### Wire them in the anchor factory using function references

```kotlin
fun RememberAnchorScope.mainAnchor(): MainAnchor =
  create(
    initialState = ::mainViewState,
    effectScope = { MainEffect() },
    init = MainAnchor::sayHi,
    subscriptions = MainSubScope::subscriptions,
    defect = MainAnchor::defect,
    onDomainError = MainAnchor::onError,
  )
```

### Two error patterns demonstrated

**Local error** — caught in the action, reduces state to show dialog:
```kotlin
suspend fun MainAnchor.triggerLocalError() {
  try {
    effect { failingEffect() }
  } catch (e: Exception) {
    reduce { copy(errorDialog = "A locally caught error occurred.") }
  }
}
```

**Propagated error** — thrown from action, caught by `ContainerViewModel.execute`, routed to `defect` callback:
```kotlin
suspend fun MainAnchor.triggerPropagatedError() {
  effect { failingEffect() }
}
```

### UI — error dialog driven by state

Both patterns set `errorDialog: String?` on `MainViewState`. When non-null, an `AlertDialog` appears with generic "Error" title, the description, and an "OK" dismiss button.

## Test plan

- [x] `./gradlew desktopTest` — all existing tests pass
- [x] `./gradlew :androidApp:assembleDebug` — Android builds
- [ ] Manual: tap "local error" → dialog shows with locally caught message → dismiss with OK
- [ ] Manual: tap "propagated error" → dialog shows with propagated message → dismiss with OK