### PR TITLE
♻️ Propagate Err type parameter to anchor-test module

### DIFF
--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
 @AnchorTestDsl
-public inline fun <reified R, reified S> runAnchorTest(
-  noinline builder: RememberAnchorScope.() -> Anchor<R, S, *>,
-  crossinline block: suspend AnchorTestScope<R, S>.() -> Unit,
+public inline fun <reified R, reified S, Err : Any> runAnchorTest(
+  noinline builder: RememberAnchorScope.() -> Anchor<R, S, Err>,
+  crossinline block: suspend AnchorTestScope<R, S, Err>.() -> Unit,
 ): TestResult where R : Effect, S : ViewState =
   runTest {
     AnchorTestScope(builder)

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -10,12 +10,12 @@ import dev.kioba.anchor.ViewState
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi
-internal class AnchorTestRuntime<R, S>(
+internal class AnchorTestRuntime<R, S, Err>(
   @PublishedApi
   internal val effectScope: R,
   @PublishedApi
   internal val initState: S,
-) : Anchor<R, S, Nothing>() where R : Effect, S : ViewState {
+) : Anchor<R, S, Err>() where R : Effect, S : ViewState, Err : Any {
 
   val verifyActions = mutableListOf<VerifyAction>()
   private var currentState = initState
@@ -37,7 +37,7 @@ internal class AnchorTestRuntime<R, S>(
 
   override suspend fun cancellable(
     key: Any,
-    block: suspend Anchor<R, S, Nothing>.() -> Unit,
+    block: suspend Anchor<R, S, Err>.() -> Unit,
   ) {
     block()
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -9,9 +9,9 @@ import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-public class AnchorTestScope<R : Effect, S : ViewState>(
+public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @PublishedApi
-  internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S, *>,
+  internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S, Err>,
 ) {
   @PublishedApi
   internal val givenScope: GivenScopeImpl<R, S> = GivenScopeImpl()
@@ -20,7 +20,7 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
   internal val verifyScope: VerifyScopeImpl<R, S> = VerifyScopeImpl()
 
   @PublishedApi
-  internal lateinit var action: suspend Anchor<R, S, Nothing>.() -> Unit
+  internal lateinit var action: suspend Anchor<R, S, Err>.() -> Unit
 
   @AnchorTestDsl
   public inline fun given(
@@ -32,7 +32,7 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
   @AnchorTestDsl
   public fun on(
     @Suppress("UNUSED_PARAMETER") description: String,
-    anchorOf: suspend Anchor<R, S, Nothing>.() -> Unit,
+    anchorOf: suspend Anchor<R, S, Err>.() -> Unit,
   ) {
     action = anchorOf
   }
@@ -47,7 +47,7 @@ public class AnchorTestScope<R : Effect, S : ViewState>(
 }
 
 @PublishedApi
-internal suspend inline fun <reified R : Effect, reified S : ViewState> AnchorTestScope<R, S>.assert() {
+internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assert() {
   val rememberAnchorScope =
     object : RememberAnchorScope {
       @Suppress("UNCHECKED_CAST")
@@ -59,20 +59,20 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState> AnchorTe
         defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)?,
         subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)?,
       ): Anchor<R, S, Err> =
-        AnchorTestRuntime(
+        AnchorTestRuntime<R, S, Err>(
           givenScope.effectScope as? R ?: effectScope(),
           givenScope.initState as? S ?: initialState(),
-        ) as Anchor<R, S, Err>
+        )
     }
-  val anchor: AnchorTestRuntime<R, S> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S>
+  val anchor: AnchorTestRuntime<R, S, Err> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S, Err>
 
   anchor.action()
 
-  assertEvents<R, S>(anchor.verifyActions, anchor.initState, anchor.effectScope)
+  assertEvents<R, S, Err>(anchor.verifyActions, anchor.initState, anchor.effectScope)
 }
 
 @PublishedApi
-internal inline fun <reified R : Effect, reified S : ViewState> AnchorTestScope<R, S>.assertEvents(
+internal inline fun <reified R : Effect, reified S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assertEvents(
   actualActions: MutableList<VerifyAction>,
   initialState: S,
   effectScope: R,


### PR DESCRIPTION
## Summary

Closes #162

- Adds `Err : Any` third type parameter to `AnchorTestRuntime`, `AnchorTestScope`, and `runAnchorTest`
- Replaces hardcoded `Nothing` with the generic `Err` parameter throughout the test infrastructure
- `Err` is non-reified since `Nothing` (used by all existing anchors) cannot be a reified type parameter
- `GivenScope` and `VerifyScope` remain 2-param — they don't reference the error type

No changes to anchor-compose (already uses `*` wildcards), feature modules (already specify `Nothing`), or test call sites (`Err = Nothing` inferred automatically).

## Test plan

- [x] `./gradlew allTests` passes — all existing tests infer `Err = Nothing`
- [ ] Verify CI passes on all platforms (desktop, iOS simulator)