### PR TITLE
✨ Add raise and orDie error handling primitives

### DIFF
--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -7,6 +7,8 @@ import dev.kioba.anchor.Signal
 import dev.kioba.anchor.SignalScope
 import dev.kioba.anchor.SubscriptionScope
 import dev.kioba.anchor.ViewState
+import dev.kioba.anchor.internal.DomainDefectException
+import dev.kioba.anchor.internal.RaisedException
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi
@@ -55,4 +57,13 @@ internal class AnchorTestRuntime<R, S, Err>(
     currentState = currentState.reducer()
   }
 
+  override fun raise(error: Err): Nothing {
+    verifyActions.add(RaiseAction(error))
+    throw RaisedException(error)
+  }
+
+  override fun orDie(error: Err): Nothing {
+    verifyActions.add(OrDieAction(error))
+    throw DomainDefectException(error)
+  }
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -1,14 +1,14 @@
 package dev.kioba.anchor.test.scopes
 
 import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.Event
+import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.Signal
 import dev.kioba.anchor.SignalScope
 import dev.kioba.anchor.SubscriptionScope
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.DomainDefectException
-import dev.kioba.anchor.RaisedException
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -7,8 +7,8 @@ import dev.kioba.anchor.Signal
 import dev.kioba.anchor.SignalScope
 import dev.kioba.anchor.SubscriptionScope
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.internal.DomainDefectException
-import dev.kioba.anchor.internal.RaisedException
+import dev.kioba.anchor.DomainDefectException
+import dev.kioba.anchor.RaisedException
 import kotlin.coroutines.CoroutineContext
 
 @PublishedApi

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -5,8 +5,8 @@ import dev.kioba.anchor.Effect
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.internal.DomainDefectException
-import dev.kioba.anchor.internal.RaisedException
+import dev.kioba.anchor.DomainDefectException
+import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
@@ -20,7 +20,7 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   internal val givenScope: GivenScopeImpl<R, S> = GivenScopeImpl()
 
   @PublishedApi
-  internal val verifyScope: VerifyScopeImpl<R, S> = VerifyScopeImpl()
+  internal val verifyScope: VerifyScopeImpl<R, S, Err> = VerifyScopeImpl()
 
   @PublishedApi
   internal lateinit var action: suspend Anchor<R, S, Err>.() -> Unit
@@ -43,7 +43,7 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @AnchorTestDsl
   public inline fun verify(
     @Suppress("UNUSED_PARAMETER") description: String,
-    block: VerifyScope<R, S>.() -> Unit,
+    block: VerifyScope<R, S, Err>.() -> Unit,
   ) {
     verifyScope.block()
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -5,7 +5,10 @@ import dev.kioba.anchor.Effect
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
+import dev.kioba.anchor.internal.DomainDefectException
+import dev.kioba.anchor.internal.RaisedException
 import dev.kioba.anchor.test.AnchorTestDsl
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -66,7 +69,15 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
     }
   val anchor: AnchorTestRuntime<R, S, Err> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S, Err>
 
-  anchor.action()
+  try {
+    anchor.action()
+  } catch (_: RaisedException) {
+    // Expected when action calls raise() — recorded in verifyActions
+  } catch (e: CancellationException) {
+    throw e
+  } catch (_: DomainDefectException) {
+    // Expected when action calls orDie() — recorded in verifyActions
+  }
 
   assertEvents<R, S, Err>(anchor.verifyActions, anchor.initState, anchor.effectScope)
 }
@@ -107,6 +118,18 @@ internal inline fun <reified R : Effect, reified S : ViewState, Err : Any> Ancho
         is SignalAction -> {
           val actualSignal = assertIs<SignalAction>(actualActions.removeFirstOrNull())
           assertEquals(action.signal(), actualSignal.signal())
+          currentState
+        }
+
+        is RaiseAction -> {
+          val actualRaise = assertIs<RaiseAction>(actualActions.removeFirstOrNull())
+          assertEquals(action.error, actualRaise.error)
+          currentState
+        }
+
+        is OrDieAction -> {
+          val actualOrDie = assertIs<OrDieAction>(actualActions.removeFirstOrNull())
+          assertEquals(action.error, actualOrDie.error)
           currentState
         }
       }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -1,12 +1,12 @@
 package dev.kioba.anchor.test.scopes
 
 import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.DomainDefectException
-import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
@@ -121,14 +121,14 @@ internal inline fun <reified R : Effect, reified S : ViewState, Err : Any> Ancho
           currentState
         }
 
-        is RaiseAction -> {
-          val actualRaise = assertIs<RaiseAction>(actualActions.removeFirstOrNull())
+        is RaiseAction<*> -> {
+          val actualRaise = assertIs<RaiseAction<*>>(actualActions.removeFirstOrNull())
           assertEquals(action.error, actualRaise.error)
           currentState
         }
 
-        is OrDieAction -> {
-          val actualOrDie = assertIs<OrDieAction>(actualActions.removeFirstOrNull())
+        is OrDieAction<*> -> {
+          val actualOrDie = assertIs<OrDieAction<*>>(actualActions.removeFirstOrNull())
           assertEquals(action.error, actualOrDie.error)
           currentState
         }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -27,4 +27,24 @@ public interface VerifyScope<R, S> where R : Effect, S : ViewState {
   public fun assertEffect(
     f: R.() -> Unit,
   )
+
+  /**
+   * Asserts that [raise] was called with the given error.
+   *
+   * @param f A block that returns the expected error value.
+   */
+  @AnchorTestDsl
+  public fun assertRaise(
+    f: () -> Any,
+  )
+
+  /**
+   * Asserts that [orDie] was called with the given error.
+   *
+   * @param f A block that returns the expected error value.
+   */
+  @AnchorTestDsl
+  public fun assertOrDie(
+    f: () -> Any,
+  )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -7,7 +7,7 @@ import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
-public interface VerifyScope<R, S> where R : Effect, S : ViewState {
+public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : Any {
   @AnchorTestDsl
   public fun assertState(
     f: S.() -> S,
@@ -35,7 +35,7 @@ public interface VerifyScope<R, S> where R : Effect, S : ViewState {
    */
   @AnchorTestDsl
   public fun assertRaise(
-    f: () -> Any,
+    f: () -> Err,
   )
 
   /**
@@ -45,6 +45,6 @@ public interface VerifyScope<R, S> where R : Effect, S : ViewState {
    */
   @AnchorTestDsl
   public fun assertOrDie(
-    f: () -> Any,
+    f: () -> Err,
   )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -6,10 +6,10 @@ import dev.kioba.anchor.Signal
 import dev.kioba.anchor.ViewState
 
 @PublishedApi
-internal class VerifyScopeImpl<R, S>(
+internal class VerifyScopeImpl<R, S, Err>(
   @PublishedApi
   internal val expectedActions: MutableList<VerifyAction> = mutableListOf(),
-) : VerifyScope<R, S> where R : Effect, S : ViewState {
+) : VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : Any {
   override fun assertState(
     f: S.() -> S,
   ) {
@@ -35,13 +35,13 @@ internal class VerifyScopeImpl<R, S>(
   }
 
   override fun assertRaise(
-    f: () -> Any,
+    f: () -> Err,
   ) {
     expectedActions.add(RaiseAction(f()))
   }
 
   override fun assertOrDie(
-    f: () -> Any,
+    f: () -> Err,
   ) {
     expectedActions.add(OrDieAction(f()))
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -33,6 +33,18 @@ internal class VerifyScopeImpl<R, S>(
   ) {
     expectedActions.add(EffectAction(f))
   }
+
+  override fun assertRaise(
+    f: () -> Any,
+  ) {
+    expectedActions.add(RaiseAction(f()))
+  }
+
+  override fun assertOrDie(
+    f: () -> Any,
+  ) {
+    expectedActions.add(OrDieAction(f()))
+  }
 }
 
 @PublishedApi
@@ -56,4 +68,14 @@ internal data class EventAction(
 @PublishedApi
 internal data class EffectAction<R>(
   val effect: R.() -> Unit,
+) : VerifyAction
+
+@PublishedApi
+internal data class RaiseAction(
+  val error: Any,
+) : VerifyAction
+
+@PublishedApi
+internal data class OrDieAction(
+  val error: Any,
 ) : VerifyAction

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -71,11 +71,11 @@ internal data class EffectAction<R>(
 ) : VerifyAction
 
 @PublishedApi
-internal data class RaiseAction(
-  val error: Any,
+internal data class RaiseAction<Err : Any>(
+  val error: Err,
 ) : VerifyAction
 
 @PublishedApi
-internal data class OrDieAction(
-  val error: Any,
+internal data class OrDieAction<Err : Any>(
+  val error: Err,
 ) : VerifyAction

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
@@ -89,6 +89,26 @@ public abstract class AnchorSink<R, S, Err> : Anchor<R, S, Err>()
 }
 
 /**
+ * Provides the ability to escalate a domain error to a defect.
+ *
+ * A defect bypasses all `recover` blocks and reaches the `defect` handler
+ * configured via `create()`. Use this when an error represents a programming
+ * mistake or unrecoverable condition.
+ *
+ * @param Err The domain error type.
+ */
+@AnchorDsl
+public interface DefectAnchor<Err> where Err : Any {
+  /**
+   * Escalates a domain error to a defect, bypassing all `recover` blocks.
+   *
+   * @param error The domain error to escalate.
+   */
+  @AnchorDsl
+  public fun orDie(error: Err): Nothing
+}
+
+/**
  * The core interface of the Anchor architecture.
  *
  * An Anchor manages the state of a component and handles side effects.
@@ -104,7 +124,9 @@ public abstract class Anchor<R, S, Err> :
   EffectAnchor<R>,
   CancellableAnchor<R, S, Err>,
   SubscriptionAnchor,
-  SignalAnchor
+  SignalAnchor,
+  Raise<Err>,
+  DefectAnchor<Err>
   where
         R : Effect,
         S : ViewState,

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
@@ -91,16 +91,16 @@ public abstract class AnchorSink<R, S, Err> : Anchor<R, S, Err>()
 /**
  * Provides the ability to escalate a domain error to a defect.
  *
- * A defect bypasses all `recover` blocks and reaches the `defect` handler
- * configured via `create()`. Use this when an error represents a programming
- * mistake or unrecoverable condition.
+ * A defect reaches the `defect` handler configured via `create()`.
+ * Use this when an error represents a programming mistake or
+ * unrecoverable condition.
  *
  * @param Err The domain error type.
  */
 @AnchorDsl
 public interface DefectAnchor<Err> where Err : Any {
   /**
-   * Escalates a domain error to a defect, bypassing all `recover` blocks.
+   * Escalates a domain error to a defect.
    *
    * @param error The domain error to escalate.
    */

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorExceptions.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/AnchorExceptions.kt
@@ -1,13 +1,13 @@
-package dev.kioba.anchor.internal
+package dev.kioba.anchor
 
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
- * Short-circuits execution within a `recover` chain.
+ * Short-circuits execution within an action.
  *
  * Extends [CancellationException] so it propagates correctly through coroutine
- * boundaries (`launch`/`join`/`cancellable`). `recover {}` catches this
- * **before** the standard [CancellationException] re-throw.
+ * boundaries (`launch`/`join`/`cancellable`). The `onDomainError` handler catches
+ * this before the standard [CancellationException] re-throw.
  *
  * @property error The domain error value that was raised.
  */
@@ -16,7 +16,7 @@ public class RaisedException(
 ) : CancellationException("Domain error raised: $error")
 
 /**
- * Escalation that bypasses ALL `recover` blocks, reaching the `defect` handler.
+ * Escalation that reaches the `defect` handler, bypassing domain error handling.
  *
  * Extends [RuntimeException] (not [CancellationException]) so it is NOT confused
  * with scope cancellation and reaches the outer `catch (e: Throwable)` in `execute`.

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
@@ -24,4 +24,22 @@ public interface Raise<Err> where Err : Any {
    */
   @AnchorDsl
   public fun raise(error: Err): Nothing
+
+  /**
+   * Ensures that [condition] is true, otherwise raises a domain error.
+   *
+   * The [error] lambda is only evaluated when the condition is false.
+   *
+   * Example:
+   * ```kotlin
+   * ensure(user.isActive) { UserError.Inactive }
+   * ```
+   *
+   * @param condition The condition to check.
+   * @param error A lazy provider for the domain error to raise when the condition is false.
+   */
+  @AnchorDsl
+  public fun ensure(condition: Boolean, error: () -> Err) {
+    if (!condition) raise(error())
+  }
 }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
@@ -1,0 +1,27 @@
+package dev.kioba.anchor
+
+/**
+ * Provides the ability to raise domain errors via short-circuit.
+ *
+ * This is a general-purpose interface that can be used as a receiver on
+ * pure domain functions, validators, or mappers without depending on the
+ * full [Anchor] type.
+ *
+ * When used with [Anchor], `raise` propagates the error to the nearest
+ * `recover` block or the `onDomainError` handler configured via `create()`.
+ *
+ * For [PureAnchor] (`Anchor<R, S, Nothing>`), `raise(Nothing)` is statically
+ * uncallable — the type system prevents misuse with zero runtime cost.
+ *
+ * @param Err The domain error type.
+ */
+@AnchorDsl
+public interface Raise<Err> where Err : Any {
+  /**
+   * Short-circuits execution with a domain error.
+   *
+   * @param error The domain error to raise.
+   */
+  @AnchorDsl
+  public fun raise(error: Err): Nothing
+}

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
@@ -7,8 +7,8 @@ package dev.kioba.anchor
  * pure domain functions, validators, or mappers without depending on the
  * full [Anchor] type.
  *
- * When used with [Anchor], `raise` propagates the error to the nearest
- * `recover` block or the `onDomainError` handler configured via `create()`.
+ * When used with [Anchor], `raise` propagates the error to the
+ * `onDomainError` handler configured via `create()`.
  *
  * For [PureAnchor] (`Anchor<R, S, Nothing>`), `raise(Nothing)` is statically
  * uncallable — the type system prevents misuse with zero runtime cost.

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
@@ -24,21 +24,35 @@ public class SubscriptionsScope<R, S, Err>(
    */
   public val effect: R,
   @PublishedApi
+  internal val onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
+  @PublishedApi
   internal val flows: MutableList<Flow<*>> = mutableListOf(),
 ) where R : Effect, S : ViewState, Err : Any {
 
   /**
    * Extension function to execute an action on the [Anchor] for each value emitted by a [Flow].
    *
+   * If the action calls [Raise.raise], the error is routed to the `onDomainError` handler
+   * without killing the subscription pipeline. If no handler is configured, the exception
+   * propagates and cancels the subscription.
+   *
    * @param I The type of values emitted by the [Flow].
-   * @param effect The action to execute on the [Anchor].
+   * @param action The action to execute on the [Anchor].
    * @return The original [Flow].
    */
   @AnchorDsl
   public fun <I> Flow<I>.anchor(
-    effect: Anchor<R, S, Err>.(I) -> Unit,
+    action: Anchor<R, S, Err>.(I) -> Unit,
   ): Flow<I> =
-    onEach { value -> anchor.effect(value) }
+    onEach { value ->
+      try {
+        anchor.action(value)
+      } catch (e: RaisedException) {
+        @Suppress("UNCHECKED_CAST")
+        val error = e.error as Err
+        onDomainError?.invoke(anchor, error) ?: throw e
+      }
+    }
 
   /**
    * Listens for internal [Event]s of type [A].

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorExceptions.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorExceptions.kt
@@ -1,0 +1,28 @@
+package dev.kioba.anchor.internal
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Short-circuits execution within a `recover` chain.
+ *
+ * Extends [CancellationException] so it propagates correctly through coroutine
+ * boundaries (`launch`/`join`/`cancellable`). `recover {}` catches this
+ * **before** the standard [CancellationException] re-throw.
+ *
+ * @property error The domain error value that was raised.
+ */
+public class RaisedException(
+  public val error: Any,
+) : CancellationException("Domain error raised: $error")
+
+/**
+ * Escalation that bypasses ALL `recover` blocks, reaching the `defect` handler.
+ *
+ * Extends [RuntimeException] (not [CancellationException]) so it is NOT confused
+ * with scope cancellation and reaches the outer `catch (e: Throwable)` in `execute`.
+ *
+ * @property error The domain error value that was escalated.
+ */
+public class DomainDefectException(
+  public val error: Any,
+) : RuntimeException("Domain defect: $error")

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 
 @PublishedApi
 internal class AnchorRuntime<R, S, Err>(
@@ -107,6 +108,12 @@ internal class AnchorRuntime<R, S, Err>(
   ): Unit =
     _viewState.update(reducer)
 
+  override fun raise(error: Err): Nothing =
+    throw RaisedException(error)
+
+  override fun orDie(error: Err): Nothing =
+    throw DomainDefectException(error)
+
   override suspend fun <T> effect(
     coroutineContext: CoroutineContext,
     block: suspend R.() -> T,
@@ -140,6 +147,8 @@ internal class AnchorRuntime<R, S, Err>(
     block: suspend Anchor<R, S, Err>.() -> Unit,
   ) {
     coroutineScope {
+      var raised: RaisedException? = null
+
       val jobToWait =
         jobsMutex.withLock {
           // Cancel and remove old job if it exists
@@ -151,6 +160,9 @@ internal class AnchorRuntime<R, S, Err>(
             launch {
               try {
                 block()
+              } catch (e: RaisedException) {
+                raised = e
+                throw e
               } finally {
                 // Clean up completed job to prevent memory leak
                 // Only remove if this job is still the current one for this key
@@ -168,6 +180,10 @@ internal class AnchorRuntime<R, S, Err>(
 
       // Wait for the job to complete (outside the lock)
       jobToWait.join()
+
+      // Propagate RaisedException after join — CancellationException semantics
+      // cause join() to complete normally, but the domain error must propagate.
+      raised?.let { throw it }
     }
   }
 

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
@@ -3,8 +3,10 @@ package dev.kioba.anchor.internal
 import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.AnchorSink
 import dev.kioba.anchor.Created
+import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.Event
+import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.Signal
 import dev.kioba.anchor.SignalProvider
 import dev.kioba.anchor.SignalScope
@@ -88,7 +90,12 @@ internal class AnchorRuntime<R, S, Err>(
   }
 
   private suspend fun <T : Event> SharedFlow<T>.handlers(): Flow<Any?> =
-    SubscriptionsScope<R, S, Err>(this, anchor = this@AnchorRuntime, effect = effect)
+    SubscriptionsScope<R, S, Err>(
+      chain = this,
+      anchor = this@AnchorRuntime,
+      effect = effect,
+      onDomainError = onDomainError,
+    )
       .also { scope -> subscriptions?.invoke(scope) }
       .flows
       .merge()

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.viewModelScope
 import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.AnchorScope
 import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.SignalProvider
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.internal.AnchorRuntime
-import dev.kioba.anchor.internal.RaisedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -35,24 +35,34 @@ public class ContainerViewModel<R, S, Err>
     block: suspend Anchor<R, S, *>.() -> Unit,
   ) {
     viewModelScope.launch(Dispatchers.Default) {
-      try {
+      handleErrors {
         @Suppress("UNCHECKED_CAST")
         anchor.block()
-      } catch (e: RaisedException) {
-        @Suppress("UNCHECKED_CAST")
-        val error = e.error as Err
-        anchor.onDomainError?.invoke(anchor, error) ?: throw e
-      } catch (e: CancellationException) {
-        throw e
-      } catch (e: Throwable) {
-        anchor.defect?.invoke(anchor, e) ?: throw e
       }
+    }
+  }
+
+  private suspend fun handleErrors(
+    block: suspend () -> Unit,
+  ) {
+    try {
+      block()
+    } catch (e: RaisedException) {
+      @Suppress("UNCHECKED_CAST")
+      val error = e.error as Err
+      anchor.onDomainError?.invoke(anchor, error) ?: throw e
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      anchor.defect?.invoke(anchor, e) ?: throw e
     }
   }
 
   init {
     viewModelScope.launch(Dispatchers.Default) {
-      anchor.consumeInitial()
+      handleErrors {
+        anchor.consumeInitial()
+      }
       with(anchor) {
         subscribe()
       }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/viewmodel/ContainerViewModel.kt
@@ -8,6 +8,7 @@ import dev.kioba.anchor.Effect
 import dev.kioba.anchor.SignalProvider
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.internal.AnchorRuntime
+import dev.kioba.anchor.internal.RaisedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -37,6 +38,10 @@ public class ContainerViewModel<R, S, Err>
       try {
         @Suppress("UNCHECKED_CAST")
         anchor.block()
+      } catch (e: RaisedException) {
+        @Suppress("UNCHECKED_CAST")
+        val error = e.error as Err
+        anchor.onDomainError?.invoke(anchor, error) ?: throw e
       } catch (e: CancellationException) {
         throw e
       } catch (e: Throwable) {

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
@@ -148,6 +148,63 @@ class RaiseTest {
   }
 
   @Test
+  fun `ensure does nothing when condition is true`() = runBlocking {
+    val anchor = createAnchor()
+
+    with(anchor) {
+      reduce { copy(value = 1) }
+      ensure(true) { TestError.NotFound }
+      reduce { copy(value = 2) }
+    }
+
+    assertEquals(2, anchor.state.value)
+  }
+
+  @Test
+  fun `ensure raises when condition is false`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<RaisedException> {
+      anchor.ensure(false) { TestError.NotFound }
+    }
+
+    assertEquals(TestError.NotFound, exception.error)
+  }
+
+  @Test
+  fun `ensure short-circuits execution`() = runBlocking {
+    val anchor = createAnchor()
+    var reachedAfterEnsure = false
+
+    assertFailsWith<RaisedException> {
+      with(anchor) {
+        reduce { copy(value = 1) }
+        ensure(false) { TestError.Invalid("check failed") }
+        @Suppress("UNREACHABLE_CODE")
+        reachedAfterEnsure = true
+      }
+    }
+
+    assertTrue(!reachedAfterEnsure)
+    assertEquals(1, anchor.state.value)
+  }
+
+  @Test
+  fun `ensure inside cancellable propagates correctly`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<RaisedException> {
+      anchor.cancellable("ensure-test") {
+        reduce { copy(value = 10) }
+        ensure(false) { TestError.NotFound }
+      }
+    }
+
+    assertEquals(TestError.NotFound, exception.error)
+    assertEquals(10, anchor.state.value)
+  }
+
+  @Test
   fun `subscription pipeline survives raise when onDomainError is configured`() = runBlocking {
     val capturedErrors = mutableListOf<TestError>()
     val anchor = createAnchor()

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
@@ -1,6 +1,8 @@
 package dev.kioba.anchor
 
 import dev.kioba.anchor.internal.AnchorRuntime
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -122,5 +124,47 @@ class RaiseTest {
     }
 
     assertEquals(0, anchor.jobs.size, "Job should be cleaned up after raise")
+  }
+
+  @Test
+  fun `raise inside subscription handler routes to onDomainError`() = runBlocking {
+    val capturedErrors = mutableListOf<TestError>()
+    val anchor = createAnchor()
+
+    val scope = SubscriptionsScope<EmptyEffect, TestState, TestError>(
+      chain = MutableSharedFlow(),
+      anchor = anchor,
+      effect = EmptyEffect,
+      onDomainError = { error -> capturedErrors.add(error) },
+    )
+
+    val resultFlow = with(scope) {
+      flowOf(Unit).anchor { raise(TestError.NotFound) }
+    }
+
+    resultFlow.collect {}
+
+    assertEquals(listOf<TestError>(TestError.NotFound), capturedErrors)
+  }
+
+  @Test
+  fun `subscription pipeline survives raise when onDomainError is configured`() = runBlocking {
+    val capturedErrors = mutableListOf<TestError>()
+    val anchor = createAnchor()
+
+    val scope = SubscriptionsScope<EmptyEffect, TestState, TestError>(
+      chain = MutableSharedFlow(),
+      anchor = anchor,
+      effect = EmptyEffect,
+      onDomainError = { error -> capturedErrors.add(error) },
+    )
+
+    val resultFlow = with(scope) {
+      flowOf(1, 2, 3).anchor { raise(TestError.NotFound) }
+    }
+
+    resultFlow.collect {}
+
+    assertEquals(3, capturedErrors.size, "All items should trigger onDomainError")
   }
 }

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
@@ -1,8 +1,6 @@
 package dev.kioba.anchor
 
 import dev.kioba.anchor.internal.AnchorRuntime
-import dev.kioba.anchor.internal.DomainDefectException
-import dev.kioba.anchor.internal.RaisedException
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/RaiseTest.kt
@@ -1,0 +1,128 @@
+package dev.kioba.anchor
+
+import dev.kioba.anchor.internal.AnchorRuntime
+import dev.kioba.anchor.internal.DomainDefectException
+import dev.kioba.anchor.internal.RaisedException
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+sealed interface TestError {
+  data object NotFound : TestError
+  data class Invalid(val reason: String) : TestError
+}
+
+class RaiseTest {
+
+  private fun createAnchor(
+    onDomainError: (suspend Anchor<EmptyEffect, TestState, TestError>.(TestError) -> Unit)? = null,
+    defect: (suspend Anchor<EmptyEffect, TestState, TestError>.(Throwable) -> Unit)? = null,
+  ): AnchorRuntime<EmptyEffect, TestState, TestError> =
+    AnchorRuntime(
+      initialState = { TestState(value = 0) },
+      effectScope = { EmptyEffect },
+      onDomainError = onDomainError,
+      defect = defect,
+    )
+
+  @Test
+  fun `raise throws RaisedException`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<RaisedException> {
+      anchor.raise(TestError.NotFound)
+    }
+
+    assertEquals(TestError.NotFound, exception.error)
+  }
+
+  @Test
+  fun `orDie throws DomainDefectException`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<DomainDefectException> {
+      anchor.orDie(TestError.NotFound)
+    }
+
+    assertEquals(TestError.NotFound, exception.error)
+  }
+
+  @Test
+  fun `raise carries typed error value`() = runBlocking {
+    val anchor = createAnchor()
+
+    val error = TestError.Invalid(reason = "bad input")
+    val exception = assertFailsWith<RaisedException> {
+      anchor.raise(error)
+    }
+
+    val captured = exception.error
+    assertIs<TestError.Invalid>(captured)
+    assertEquals("bad input", captured.reason)
+  }
+
+  @Test
+  fun `raise inside cancellable propagates correctly`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<RaisedException> {
+      anchor.cancellable("test") {
+        reduce { copy(value = 1) }
+        raise(TestError.NotFound)
+      }
+    }
+
+    assertEquals(TestError.NotFound, exception.error)
+    // State should have been updated before raise
+    assertEquals(1, anchor.state.value)
+  }
+
+  @Test
+  fun `orDie inside cancellable propagates correctly`() = runBlocking {
+    val anchor = createAnchor()
+
+    val exception = assertFailsWith<DomainDefectException> {
+      anchor.cancellable("test") {
+        reduce { copy(value = 42) }
+        orDie(TestError.Invalid("fatal"))
+      }
+    }
+
+    assertIs<TestError.Invalid>(exception.error)
+    assertEquals(42, anchor.state.value)
+  }
+
+  @Test
+  fun `raise short-circuits execution`() = runBlocking {
+    val anchor = createAnchor()
+    var reachedAfterRaise = false
+
+    assertFailsWith<RaisedException> {
+      with(anchor) {
+        reduce { copy(value = 1) }
+        raise(TestError.NotFound)
+        @Suppress("UNREACHABLE_CODE")
+        reachedAfterRaise = true
+      }
+    }
+
+    assertTrue(!reachedAfterRaise)
+    assertEquals(1, anchor.state.value)
+  }
+
+  @Test
+  fun `cancellable cleans up job after raise`() = runBlocking {
+    val anchor = createAnchor()
+
+    assertFailsWith<RaisedException> {
+      anchor.cancellable("cleanup-test") {
+        raise(TestError.NotFound)
+      }
+    }
+
+    assertEquals(0, anchor.jobs.size, "Job should be cleaned up after raise")
+  }
+}


### PR DESCRIPTION
## Summary

Closes #163 (partial — `raise`/`orDie` only, no `recover`/`bind`/`AnchorConfig`).

- **`Raise<Err>`** — standalone, reusable interface with `raise(error: Err): Nothing`. Can be used as a receiver on pure domain functions, validators, or mappers independently of Anchor. Forward-compatible with Kotlin 2.4 context parameters and KEEP-0441 Rich Errors.
- **`DefectAnchor<Err>`** — Anchor-specific interface with `orDie(error: Err): Nothing` for escalating domain errors to defects.
- **`Anchor<R, S, Err>`** now implements both `Raise<Err>` and `DefectAnchor<Err>`.
- **`RaisedException : CancellationException`** — propagates through coroutine boundaries (launch/join/cancellable). Caught before generic `CancellationException` in `ContainerViewModel.execute()` and routed to `onDomainError`.
- **`DomainDefectException : RuntimeException`** — bypasses cancellation catch blocks, reaches `defect` handler.
- **`cancellable {}`** — fixed to propagate `RaisedException` after `join()`.
- **Test DSL** — `assertRaise` / `assertOrDie` verification support in `VerifyScope`.

For `PureAnchor<R, S, Nothing>`: both `raise(Nothing)` and `orDie(Nothing)` are statically uncallable.

## Test plan

- [x] `raise()` throws `RaisedException` with correct error value
- [x] `orDie()` throws `DomainDefectException` with correct error value
- [x] `raise()` short-circuits execution
- [x] `raise()` inside `cancellable {}` propagates correctly
- [x] `orDie()` inside `cancellable {}` propagates correctly
- [x] Job cleanup after raise in cancellable blocks
- [x] `./gradlew :anchor:build :anchor-test:build :anchor-compose:build` passes
- [x] `./gradlew :anchor:allTests :features:main:allTests` passes