### PR TITLE
✨ Error handling test infrastructure

### DIFF
--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/AnchorTest.kt
@@ -9,7 +9,6 @@ import dev.kioba.anchor.test.scopes.assert
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
-@AnchorTestDsl
 public inline fun <reified R, reified S, Err : Any> runAnchorTest(
   noinline builder: RememberAnchorScope.() -> Anchor<R, S, Err>,
   crossinline block: suspend AnchorTestScope<R, S, Err>.() -> Unit,

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -20,6 +20,11 @@ internal class AnchorTestRuntime<R, S, Err>(
 ) : Anchor<R, S, Err>() where R : Effect, S : ViewState, Err : Any {
 
   val verifyActions = mutableListOf<VerifyAction>()
+  @PublishedApi
+  internal val domainErrors: MutableList<Any> = mutableListOf()
+
+  @PublishedApi
+  internal val defects: MutableList<Throwable> = mutableListOf()
   private var currentState = initState
 
   override val state: S

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -3,6 +3,7 @@ package dev.kioba.anchor.test.scopes
 import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
+import dev.kioba.anchor.ErrorScope
 import dev.kioba.anchor.Event
 import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.Signal
@@ -18,17 +19,18 @@ internal class AnchorTestRuntime<R, S, Err>(
   @PublishedApi
   internal val initState: S,
   @PublishedApi
-  internal val onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
+  internal val onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)? = null,
   @PublishedApi
-  internal val defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null,
+  internal val defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)? = null,
 ) : Anchor<R, S, Err>() where R : Effect, S : ViewState, Err : Any {
 
   val verifyActions = mutableListOf<VerifyAction>()
-  @PublishedApi
-  internal val domainErrors: MutableList<Err> = mutableListOf()
 
   @PublishedApi
-  internal val defects: MutableList<Throwable> = mutableListOf()
+  internal var capturedDomainError: Err? = null
+
+  @PublishedApi
+  internal var capturedDefect: Throwable? = null
   private var currentState = initState
 
   override val state: S

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestRuntime.kt
@@ -17,11 +17,15 @@ internal class AnchorTestRuntime<R, S, Err>(
   internal val effectScope: R,
   @PublishedApi
   internal val initState: S,
+  @PublishedApi
+  internal val onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null,
+  @PublishedApi
+  internal val defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null,
 ) : Anchor<R, S, Err>() where R : Effect, S : ViewState, Err : Any {
 
   val verifyActions = mutableListOf<VerifyAction>()
   @PublishedApi
-  internal val domainErrors: MutableList<Any> = mutableListOf()
+  internal val domainErrors: MutableList<Err> = mutableListOf()
 
   @PublishedApi
   internal val defects: MutableList<Throwable> = mutableListOf()

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -12,13 +12,14 @@ import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @PublishedApi
   internal val anchorFactory: RememberAnchorScope.() -> Anchor<R, S, Err>,
 ) {
   @PublishedApi
-  internal val givenScope: GivenScopeImpl<R, S> = GivenScopeImpl()
+  internal val givenScope: GivenScopeImpl<R, S, Err> = GivenScopeImpl()
 
   @PublishedApi
   internal val verifyScope: VerifyScopeImpl<R, S, Err> = VerifyScopeImpl()
@@ -29,7 +30,7 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @AnchorTestDsl
   public inline fun given(
     @Suppress("UNUSED_PARAMETER") description: String,
-    block: GivenScope<R, S>.() -> Unit,
+    block: GivenScope<R, S, Err>.() -> Unit,
   ): Unit =
     givenScope.block()
 
@@ -52,6 +53,11 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
 
 @PublishedApi
 internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assert() {
+  var resolvedOnDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null
+  var resolvedDefect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null
+  var factoryOnDomainError: Any? = null
+  var factoryDefect: Any? = null
+
   val rememberAnchorScope =
     object : RememberAnchorScope {
       @Suppress("UNCHECKED_CAST")
@@ -62,25 +68,67 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
         onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)?,
         defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)?,
         subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)?,
-      ): Anchor<R, S, Err> =
-        AnchorTestRuntime<R, S, Err>(
+      ): Anchor<R, S, Err> {
+        factoryOnDomainError = onDomainError
+        factoryDefect = defect
+        return AnchorTestRuntime<R, S, Err>(
           givenScope.effectScope as? R ?: effectScope(),
           givenScope.initState as? S ?: initialState(),
         )
+      }
     }
+
   val anchor: AnchorTestRuntime<R, S, Err> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S, Err>
+
+  @Suppress("UNCHECKED_CAST")
+  resolvedOnDomainError = givenScope.onDomainError
+    ?: factoryOnDomainError as? (suspend Anchor<R, S, Err>.(Err) -> Unit)
+  @Suppress("UNCHECKED_CAST")
+  resolvedDefect = givenScope.defect
+    ?: factoryDefect as? (suspend Anchor<R, S, Err>.(Throwable) -> Unit)
 
   try {
     anchor.action()
-  } catch (_: RaisedException) {
-    // Expected when action calls raise() — recorded in verifyActions
+  } catch (e: RaisedException) {
+    val handler = resolvedOnDomainError
+    if (handler != null) {
+      @Suppress("UNCHECKED_CAST")
+      val error = e.error as Err
+      anchor.domainErrors.add(error)
+      handler.invoke(anchor, error)
+    }
   } catch (e: CancellationException) {
     throw e
-  } catch (_: DomainDefectException) {
-    // Expected when action calls orDie() — recorded in verifyActions
+  } catch (e: DomainDefectException) {
+    val handler = resolvedDefect
+    if (handler != null) {
+      anchor.defects.add(e)
+      handler.invoke(anchor, e)
+    }
   }
 
   assertEvents<R, S, Err>(anchor.verifyActions, anchor.initState, anchor.effectScope)
+  assertHandlers(anchor)
+}
+
+@PublishedApi
+internal fun <R : Effect, S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assertHandlers(
+  anchor: AnchorTestRuntime<R, S, Err>,
+) {
+  verifyScope.domainErrorAssertion?.let { assertion ->
+    assertTrue(anchor.domainErrors.isNotEmpty(), "Expected onDomainError to be called, but it was not")
+    @Suppress("UNCHECKED_CAST")
+    assertEquals(assertion(), anchor.domainErrors.first() as Err)
+  }
+
+  if (verifyScope.noDomainErrorFlag) {
+    assertTrue(anchor.domainErrors.isEmpty(), "Expected no domain error, but got: ${anchor.domainErrors}")
+  }
+
+  verifyScope.defectAssertion?.let { assertion ->
+    assertTrue(anchor.defects.isNotEmpty(), "Expected defect handler to be called, but it was not")
+    assertEquals(assertion(), anchor.defects.first())
+  }
 }
 
 @PublishedApi

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -53,11 +53,6 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
 
 @PublishedApi
 internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assert() {
-  var resolvedOnDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null
-  var resolvedDefect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null
-  var factoryOnDomainError: Any? = null
-  var factoryDefect: Any? = null
-
   val rememberAnchorScope =
     object : RememberAnchorScope {
       @Suppress("UNCHECKED_CAST")
@@ -68,42 +63,34 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
         onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)?,
         defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)?,
         subscriptions: (suspend SubscriptionsScope<R, S, Err>.() -> Unit)?,
-      ): Anchor<R, S, Err> {
-        factoryOnDomainError = onDomainError
-        factoryDefect = defect
-        return AnchorTestRuntime<R, S, Err>(
-          givenScope.effectScope as? R ?: effectScope(),
-          givenScope.initState as? S ?: initialState(),
+      ): Anchor<R, S, Err> =
+        AnchorTestRuntime<R, S, Err>(
+          effectScope = givenScope.effectScope as? R ?: effectScope(),
+          initState = givenScope.initState as? S ?: initialState(),
+          onDomainError = onDomainError,
+          defect = defect,
         )
-      }
     }
 
   val anchor: AnchorTestRuntime<R, S, Err> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S, Err>
 
-  @Suppress("UNCHECKED_CAST")
-  resolvedOnDomainError = givenScope.onDomainError
-    ?: factoryOnDomainError as? (suspend Anchor<R, S, Err>.(Err) -> Unit)
-  @Suppress("UNCHECKED_CAST")
-  resolvedDefect = givenScope.defect
-    ?: factoryDefect as? (suspend Anchor<R, S, Err>.(Throwable) -> Unit)
-
   try {
     anchor.action()
   } catch (e: RaisedException) {
-    val handler = resolvedOnDomainError
-    if (handler != null) {
+    val resolvedOnDomainError = givenScope.onDomainError ?: anchor.onDomainError
+    if (resolvedOnDomainError != null) {
       @Suppress("UNCHECKED_CAST")
       val error = e.error as Err
       anchor.domainErrors.add(error)
-      handler.invoke(anchor, error)
+      resolvedOnDomainError.invoke(anchor, error)
     }
   } catch (e: CancellationException) {
     throw e
   } catch (e: DomainDefectException) {
-    val handler = resolvedDefect
-    if (handler != null) {
+    val resolvedDefect = givenScope.defect ?: anchor.defect
+    if (resolvedDefect != null) {
       anchor.defects.add(e)
-      handler.invoke(anchor, e)
+      resolvedDefect.invoke(anchor, e)
     }
   }
 
@@ -117,8 +104,7 @@ internal fun <R : Effect, S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.a
 ) {
   verifyScope.domainErrorAssertion?.let { assertion ->
     assertTrue(anchor.domainErrors.isNotEmpty(), "Expected onDomainError to be called, but it was not")
-    @Suppress("UNCHECKED_CAST")
-    assertEquals(assertion(), anchor.domainErrors.first() as Err)
+    assertEquals(assertion(), anchor.domainErrors.first())
   }
 
   if (verifyScope.noDomainErrorFlag) {

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -83,6 +83,12 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
       val error = e.error as Err
       anchor.domainErrors.add(error)
       resolvedOnDomainError.invoke(anchor, error)
+    } else {
+      throw AssertionError(
+        "raise() was called but no onDomainError handler is configured. " +
+          "Add onDomainError { } in given {} or the anchor factory.",
+        e,
+      )
     }
   } catch (e: CancellationException) {
     throw e
@@ -91,6 +97,12 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
     if (resolvedDefect != null) {
       anchor.defects.add(e)
       resolvedDefect.invoke(anchor, e)
+    } else {
+      throw AssertionError(
+        "orDie() was called but no defect handler is configured. " +
+          "Add defect { } in given {} or the anchor factory.",
+        e,
+      )
     }
   }
 
@@ -104,6 +116,7 @@ internal fun <R : Effect, S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.a
 ) {
   verifyScope.domainErrorAssertion?.let { assertion ->
     assertTrue(anchor.domainErrors.isNotEmpty(), "Expected onDomainError to be called, but it was not")
+    assertEquals(1, anchor.domainErrors.size, "Expected exactly one domain error, but got: ${anchor.domainErrors}")
     assertEquals(assertion(), anchor.domainErrors.first())
   }
 
@@ -113,6 +126,7 @@ internal fun <R : Effect, S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.a
 
   verifyScope.defectAssertion?.let { assertion ->
     assertTrue(anchor.defects.isNotEmpty(), "Expected defect handler to be called, but it was not")
+    assertEquals(1, anchor.defects.size, "Expected exactly one defect, but got: ${anchor.defects}")
     assertEquals(assertion(), anchor.defects.first())
   }
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -8,7 +8,6 @@ import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.test.AnchorTestDsl
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -27,14 +26,12 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @PublishedApi
   internal lateinit var action: suspend Anchor<R, S, Err>.() -> Unit
 
-  @AnchorTestDsl
   public inline fun given(
     @Suppress("UNUSED_PARAMETER") description: String,
     block: GivenScope<R, S, Err>.() -> Unit,
   ): Unit =
     givenScope.block()
 
-  @AnchorTestDsl
   public fun on(
     @Suppress("UNUSED_PARAMETER") description: String,
     anchorOf: suspend Anchor<R, S, Err>.() -> Unit,
@@ -42,7 +39,6 @@ public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
     action = anchorOf
   }
 
-  @AnchorTestDsl
   public inline fun verify(
     @Suppress("UNUSED_PARAMETER") description: String,
     block: VerifyScope<R, S, Err>.() -> Unit,

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/AnchorTestScope.kt
@@ -4,14 +4,14 @@ import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.ErrorScope
-import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
-import kotlin.coroutines.cancellation.CancellationException
+import dev.kioba.anchor.internal.safeExecute
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 public class AnchorTestScope<R : Effect, S : ViewState, Err : Any>(
   @PublishedApi
@@ -63,43 +63,25 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
         AnchorTestRuntime<R, S, Err>(
           effectScope = givenScope.effectScope as? R ?: effectScope(),
           initState = givenScope.initState as? S ?: initialState(),
-          onDomainError = onDomainError,
-          defect = defect,
+          onDomainError = givenScope.onDomainError as? (suspend ErrorScope<R, S>.(Err) -> Unit) ?: onDomainError,
+          defect = givenScope.defect as? (suspend ErrorScope<R, S>.(Throwable) -> Unit) ?: defect,
         )
     }
 
   val anchor: AnchorTestRuntime<R, S, Err> = rememberAnchorScope.anchorFactory() as AnchorTestRuntime<R, S, Err>
 
-  try {
+  val recordingOnDomainError: suspend ErrorScope<R, S>.(Err) -> Unit = { error: Err ->
+    anchor.capturedDomainError = error
+    anchor.onDomainError?.invoke(this, error)
+  }
+
+  val recordingDefect: suspend ErrorScope<R, S>.(Throwable) -> Unit = { throwable: Throwable ->
+    anchor.capturedDefect = throwable
+    anchor.defect?.invoke(this, throwable)
+  }
+
+  safeExecute(anchor, recordingOnDomainError, recordingDefect) {
     anchor.action()
-  } catch (e: RaisedException) {
-    val resolvedOnDomainError = givenScope.onDomainError ?: anchor.onDomainError
-    if (resolvedOnDomainError != null) {
-      @Suppress("UNCHECKED_CAST")
-      val error = e.error as Err
-      anchor.domainErrors.add(error)
-      resolvedOnDomainError.invoke(anchor, error)
-    } else {
-      throw AssertionError(
-        "raise() was called but no onDomainError handler is configured. " +
-          "Add onDomainError { } in given {} or the anchor factory.",
-        e,
-      )
-    }
-  } catch (e: CancellationException) {
-    throw e
-  } catch (e: DomainDefectException) {
-    val resolvedDefect = givenScope.defect ?: anchor.defect
-    if (resolvedDefect != null) {
-      anchor.defects.add(e)
-      resolvedDefect.invoke(anchor, e)
-    } else {
-      throw AssertionError(
-        "orDie() was called but no defect handler is configured. " +
-          "Add defect { } in given {} or the anchor factory.",
-        e,
-      )
-    }
   }
 
   assertEvents<R, S, Err>(anchor.verifyActions, anchor.initState, anchor.effectScope)
@@ -110,20 +92,23 @@ internal suspend inline fun <reified R : Effect, reified S : ViewState, Err : An
 internal fun <R : Effect, S : ViewState, Err : Any> AnchorTestScope<R, S, Err>.assertHandlers(
   anchor: AnchorTestRuntime<R, S, Err>,
 ) {
-  verifyScope.domainErrorAssertion?.let { assertion ->
-    assertTrue(anchor.domainErrors.isNotEmpty(), "Expected onDomainError to be called, but it was not")
-    assertEquals(1, anchor.domainErrors.size, "Expected exactly one domain error, but got: ${anchor.domainErrors}")
-    assertEquals(assertion(), anchor.domainErrors.first())
+  val expectedDomainError = verifyScope.domainErrorAssertion
+  if (expectedDomainError != null) {
+    assertEquals(expectedDomainError, anchor.capturedDomainError, "Expected domain error does not match")
+  } else {
+    assertNull(anchor.capturedDomainError, "Expected no domain error, but got: ${anchor.capturedDomainError}")
   }
 
-  if (verifyScope.noDomainErrorFlag) {
-    assertTrue(anchor.domainErrors.isEmpty(), "Expected no domain error, but got: ${anchor.domainErrors}")
-  }
-
-  verifyScope.defectAssertion?.let { assertion ->
-    assertTrue(anchor.defects.isNotEmpty(), "Expected defect handler to be called, but it was not")
-    assertEquals(1, anchor.defects.size, "Expected exactly one defect, but got: ${anchor.defects}")
-    assertEquals(assertion(), anchor.defects.first())
+  val expectedDefect = verifyScope.defectAssertion
+  if (expectedDefect != null) {
+    val actual = assertNotNull(anchor.capturedDefect, "Expected defect handler to be called, but it was not")
+    if (expectedDefect is DomainDefectException && actual is DomainDefectException) {
+      assertEquals(expectedDefect.error, actual.error, "Expected defect error does not match")
+    } else {
+      assertEquals(expectedDefect, actual, "Expected defect does not match")
+    }
+  } else {
+    assertNull(anchor.capturedDefect, "Expected no defect, but got: ${anchor.capturedDefect}")
   }
 }
 

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
@@ -7,27 +7,22 @@ import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
 public interface GivenScope<R : Effect, S : ViewState, Err : Any> {
-  @AnchorTestDsl
   public fun initialState(
     f: () -> S,
   )
 
-  @AnchorTestDsl
   public suspend fun effect(
     f: R.() -> Unit,
   )
 
-  @AnchorTestDsl
   public suspend fun effectScope(
     f: () -> R,
   )
 
-  @AnchorTestDsl
   public fun onDomainError(
     f: suspend Anchor<R, S, Err>.(Err) -> Unit,
   )
 
-  @AnchorTestDsl
   public fun defect(
     f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
   )

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
@@ -1,7 +1,7 @@
 package dev.kioba.anchor.test.scopes
 
-import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.Effect
+import dev.kioba.anchor.ErrorScope
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
@@ -20,10 +20,10 @@ public interface GivenScope<R : Effect, S : ViewState, Err : Any> {
   )
 
   public fun onDomainError(
-    f: suspend Anchor<R, S, Err>.(Err) -> Unit,
+    f: suspend ErrorScope<R, S>.(Err) -> Unit,
   )
 
   public fun defect(
-    f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
+    f: suspend ErrorScope<R, S>.(Throwable) -> Unit,
   )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScope.kt
@@ -1,11 +1,12 @@
 package dev.kioba.anchor.test.scopes
 
+import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
-public interface GivenScope<R : Effect, S : ViewState> {
+public interface GivenScope<R : Effect, S : ViewState, Err : Any> {
   @AnchorTestDsl
   public fun initialState(
     f: () -> S,
@@ -19,5 +20,15 @@ public interface GivenScope<R : Effect, S : ViewState> {
   @AnchorTestDsl
   public suspend fun effectScope(
     f: () -> R,
+  )
+
+  @AnchorTestDsl
+  public fun onDomainError(
+    f: suspend Anchor<R, S, Err>.(Err) -> Unit,
+  )
+
+  @AnchorTestDsl
+  public fun defect(
+    f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
   )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
@@ -1,7 +1,7 @@
 package dev.kioba.anchor.test.scopes
 
-import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.Effect
+import dev.kioba.anchor.ErrorScope
 import dev.kioba.anchor.ViewState
 
 @PublishedApi
@@ -18,10 +18,10 @@ internal class GivenScopeImpl<R, S, Err> :
   internal val effects: MutableList<(R.() -> Unit)> = mutableListOf()
 
   @PublishedApi
-  internal var onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null
+  internal var onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)? = null
 
   @PublishedApi
-  internal var defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null
+  internal var defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)? = null
 
   override fun initialState(
     f: () -> S,
@@ -42,13 +42,13 @@ internal class GivenScopeImpl<R, S, Err> :
   }
 
   override fun onDomainError(
-    f: suspend Anchor<R, S, Err>.(Err) -> Unit,
+    f: suspend ErrorScope<R, S>.(Err) -> Unit,
   ) {
     onDomainError = f
   }
 
   override fun defect(
-    f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
+    f: suspend ErrorScope<R, S>.(Throwable) -> Unit,
   ) {
     defect = f
   }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
@@ -3,7 +3,6 @@ package dev.kioba.anchor.test.scopes
 import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.ViewState
-import dev.kioba.anchor.test.AnchorTestDsl
 
 @PublishedApi
 internal class GivenScopeImpl<R, S, Err> :
@@ -24,14 +23,12 @@ internal class GivenScopeImpl<R, S, Err> :
   @PublishedApi
   internal var defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null
 
-  @AnchorTestDsl
   override fun initialState(
     f: () -> S,
   ) {
     initState = f()
   }
 
-  @AnchorTestDsl
   override suspend fun effect(
     f: R.() -> Unit,
   ) {
@@ -44,14 +41,12 @@ internal class GivenScopeImpl<R, S, Err> :
     effectScope = f()
   }
 
-  @AnchorTestDsl
   override fun onDomainError(
     f: suspend Anchor<R, S, Err>.(Err) -> Unit,
   ) {
     onDomainError = f
   }
 
-  @AnchorTestDsl
   override fun defect(
     f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
   ) {

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/GivenScopeImpl.kt
@@ -1,11 +1,14 @@
 package dev.kioba.anchor.test.scopes
 
+import dev.kioba.anchor.Anchor
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.ViewState
 import dev.kioba.anchor.test.AnchorTestDsl
 
 @PublishedApi
-internal class GivenScopeImpl<R, S> : GivenScope<R, S> where R : Effect, S : ViewState {
+internal class GivenScopeImpl<R, S, Err> :
+  GivenScope<R, S, Err>
+  where R : Effect, S : ViewState, Err : Any {
   @PublishedApi
   internal var initState: S? = null
 
@@ -14,6 +17,12 @@ internal class GivenScopeImpl<R, S> : GivenScope<R, S> where R : Effect, S : Vie
 
   @PublishedApi
   internal val effects: MutableList<(R.() -> Unit)> = mutableListOf()
+
+  @PublishedApi
+  internal var onDomainError: (suspend Anchor<R, S, Err>.(Err) -> Unit)? = null
+
+  @PublishedApi
+  internal var defect: (suspend Anchor<R, S, Err>.(Throwable) -> Unit)? = null
 
   @AnchorTestDsl
   override fun initialState(
@@ -33,5 +42,19 @@ internal class GivenScopeImpl<R, S> : GivenScope<R, S> where R : Effect, S : Vie
     f: () -> R,
   ) {
     effectScope = f()
+  }
+
+  @AnchorTestDsl
+  override fun onDomainError(
+    f: suspend Anchor<R, S, Err>.(Err) -> Unit,
+  ) {
+    onDomainError = f
+  }
+
+  @AnchorTestDsl
+  override fun defect(
+    f: suspend Anchor<R, S, Err>.(Throwable) -> Unit,
+  ) {
+    defect = f
   }
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -47,4 +47,30 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
   public fun assertOrDie(
     f: () -> Err,
   )
+
+  /**
+   * Asserts that the `onDomainError` handler was invoked with the given error.
+   *
+   * @param f A block that returns the expected error value.
+   */
+  @AnchorTestDsl
+  public fun assertDomainError(
+    f: () -> Err,
+  )
+
+  /**
+   * Asserts that no domain error occurred during the action.
+   */
+  @AnchorTestDsl
+  public fun assertNoDomainError()
+
+  /**
+   * Asserts that the `defect` handler was invoked with the given throwable.
+   *
+   * @param f A block that returns the expected throwable.
+   */
+  @AnchorTestDsl
+  public fun assertDefect(
+    f: () -> Throwable,
+  )
 }

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -52,11 +52,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
   )
 
   /**
-   * Asserts that no domain error occurred during the action.
-   */
-  public fun assertNoDomainError()
-
-  /**
    * Asserts that the `defect` handler was invoked with the given throwable.
    *
    * @param f A block that returns the expected throwable.

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScope.kt
@@ -8,22 +8,18 @@ import dev.kioba.anchor.test.AnchorTestDsl
 
 @AnchorTestDsl
 public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : Any {
-  @AnchorTestDsl
   public fun assertState(
     f: S.() -> S,
   )
 
-  @AnchorTestDsl
   public fun assertSignal(
     f: () -> Signal,
   )
 
-  @AnchorTestDsl
   public fun assertEvent(
     f: () -> Event,
   )
 
-  @AnchorTestDsl
   public fun assertEffect(
     f: R.() -> Unit,
   )
@@ -33,7 +29,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
    *
    * @param f A block that returns the expected error value.
    */
-  @AnchorTestDsl
   public fun assertRaise(
     f: () -> Err,
   )
@@ -43,7 +38,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
    *
    * @param f A block that returns the expected error value.
    */
-  @AnchorTestDsl
   public fun assertOrDie(
     f: () -> Err,
   )
@@ -53,7 +47,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
    *
    * @param f A block that returns the expected error value.
    */
-  @AnchorTestDsl
   public fun assertDomainError(
     f: () -> Err,
   )
@@ -61,7 +54,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
   /**
    * Asserts that no domain error occurred during the action.
    */
-  @AnchorTestDsl
   public fun assertNoDomainError()
 
   /**
@@ -69,7 +61,6 @@ public interface VerifyScope<R, S, Err> where R : Effect, S : ViewState, Err : A
    *
    * @param f A block that returns the expected throwable.
    */
-  @AnchorTestDsl
   public fun assertDefect(
     f: () -> Throwable,
   )

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -47,30 +47,21 @@ internal class VerifyScopeImpl<R, S, Err>(
   }
 
   @PublishedApi
-  internal var domainErrorAssertion: (() -> Err)? = null
+  internal var domainErrorAssertion: Err? = null
 
   @PublishedApi
-  internal var noDomainErrorFlag: Boolean = false
-
-  @PublishedApi
-  internal var defectAssertion: (() -> Throwable)? = null
+  internal var defectAssertion: Throwable? = null
 
   override fun assertDomainError(
     f: () -> Err,
   ) {
-    check(!noDomainErrorFlag) { "assertDomainError and assertNoDomainError are mutually exclusive" }
-    domainErrorAssertion = f
-  }
-
-  override fun assertNoDomainError() {
-    check(domainErrorAssertion == null) { "assertNoDomainError and assertDomainError are mutually exclusive" }
-    noDomainErrorFlag = true
+    domainErrorAssertion = f()
   }
 
   override fun assertDefect(
     f: () -> Throwable,
   ) {
-    defectAssertion = f
+    defectAssertion = f()
   }
 }
 

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -46,22 +46,6 @@ internal class VerifyScopeImpl<R, S, Err>(
     expectedActions.add(OrDieAction(f()))
   }
 
-  override fun assertDomainError(
-    f: () -> Err,
-  ) {
-    domainErrorAssertion = f
-  }
-
-  override fun assertNoDomainError() {
-    noDomainErrorFlag = true
-  }
-
-  override fun assertDefect(
-    f: () -> Throwable,
-  ) {
-    defectAssertion = f
-  }
-
   @PublishedApi
   internal var domainErrorAssertion: (() -> Err)? = null
 
@@ -70,6 +54,24 @@ internal class VerifyScopeImpl<R, S, Err>(
 
   @PublishedApi
   internal var defectAssertion: (() -> Throwable)? = null
+
+  override fun assertDomainError(
+    f: () -> Err,
+  ) {
+    check(!noDomainErrorFlag) { "assertDomainError and assertNoDomainError are mutually exclusive" }
+    domainErrorAssertion = f
+  }
+
+  override fun assertNoDomainError() {
+    check(domainErrorAssertion == null) { "assertNoDomainError and assertDomainError are mutually exclusive" }
+    noDomainErrorFlag = true
+  }
+
+  override fun assertDefect(
+    f: () -> Throwable,
+  ) {
+    defectAssertion = f
+  }
 }
 
 @PublishedApi

--- a/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
+++ b/anchor-test/src/commonMain/kotlin/dev/kioba/anchor/test/scopes/VerifyScopeImpl.kt
@@ -45,6 +45,31 @@ internal class VerifyScopeImpl<R, S, Err>(
   ) {
     expectedActions.add(OrDieAction(f()))
   }
+
+  override fun assertDomainError(
+    f: () -> Err,
+  ) {
+    domainErrorAssertion = f
+  }
+
+  override fun assertNoDomainError() {
+    noDomainErrorFlag = true
+  }
+
+  override fun assertDefect(
+    f: () -> Throwable,
+  ) {
+    defectAssertion = f
+  }
+
+  @PublishedApi
+  internal var domainErrorAssertion: (() -> Err)? = null
+
+  @PublishedApi
+  internal var noDomainErrorFlag: Boolean = false
+
+  @PublishedApi
+  internal var defectAssertion: (() -> Throwable)? = null
 }
 
 @PublishedApi

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ActionOrderingTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ActionOrderingTest.kt
@@ -1,0 +1,165 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.Event
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.Signal
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+private data class OrdEffect(
+  val data: String = "test",
+) : Effect
+
+private data class OrdViewState(
+  val a: Int = 0,
+  val b: Int = 0,
+) : ViewState
+
+private sealed interface OrdSignal : Signal {
+  data object A : OrdSignal
+  data object B : OrdSignal
+}
+
+private sealed interface OrdEvent : Event {
+  data object X : OrdEvent
+  data object Y : OrdEvent
+}
+
+private typealias OrdAnchor = Anchor<OrdEffect, OrdViewState, Nothing>
+
+private fun RememberAnchorScope.ordAnchor(): OrdAnchor =
+  create(
+    initialState = ::OrdViewState,
+    effectScope = { OrdEffect() },
+  )
+
+class ActionOrderingTest {
+
+  /**
+   * Verifies that a complex sequence of interleaved reduces, signals,
+   * and events is recorded in exact execution order. Each assertion
+   * type must match the corresponding action at that position. This
+   * tests the ordered iteration in assertEvents.
+   */
+  @Test
+  fun interleavedReduceSignalEvent() =
+    runAnchorTest(RememberAnchorScope::ordAnchor) {
+      given("default state") {}
+
+      on("reduce, signal, event, reduce, signal") {
+        reduce { copy(a = 1) }
+        post { OrdSignal.A }
+        emit { OrdEvent.X }
+        reduce { copy(b = 2) }
+        post { OrdSignal.B }
+      }
+
+      verify("all five actions in exact order") {
+        assertState { copy(a = 1) }
+        assertSignal { OrdSignal.A }
+        assertEvent { OrdEvent.X }
+        assertState { copy(b = 2) }
+        assertSignal { OrdSignal.B }
+      }
+    }
+
+  /**
+   * Negative test: verifies that swapping two assertion types (signal
+   * and event) causes an AssertionError. The assertIs check in
+   * assertEvents detects the type mismatch when a SignalAction is
+   * expected but an EventAction is found (or vice versa).
+   */
+  @Test
+  fun wrongAssertionOrderFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::ordAnchor) {
+        given("default state") {}
+
+        on("signal then event") {
+          post { OrdSignal.A }
+          emit { OrdEvent.X }
+        }
+
+        verify("swapped: event then signal") {
+          assertEvent { OrdEvent.X }
+          assertSignal { OrdSignal.A }
+        }
+      }
+    }
+  }
+
+  /**
+   * Negative test: verifies that having more assertions than recorded
+   * actions causes a size mismatch AssertionError. The assertEquals
+   * on sizes fires before any individual action matching.
+   */
+  @Test
+  fun extraAssertionsFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::ordAnchor) {
+        given("default state") {}
+
+        on("one reduce") { reduce { copy(a = 1) } }
+
+        verify("two assertions for one action") {
+          assertState { copy(a = 1) }
+          assertSignal { OrdSignal.A }
+        }
+      }
+    }
+  }
+
+  /**
+   * Negative test: verifies that having fewer assertions than recorded
+   * actions causes a size mismatch AssertionError. Every recorded
+   * action must have a matching assertion.
+   */
+  @Test
+  fun missingAssertionsFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::ordAnchor) {
+        given("default state") {}
+
+        on("two actions") {
+          reduce { copy(a = 1) }
+          post { OrdSignal.A }
+        }
+
+        verify("only one assertion") {
+          assertState { copy(a = 1) }
+        }
+      }
+    }
+  }
+
+  /**
+   * Verifies that all action types (reduce, signal, event, effect, reduce)
+   * can appear in a single test. Effects are not recorded in verifyActions
+   * (they execute directly), so only non-effect actions need assertions.
+   */
+  @Test
+  fun allActionTypesInOneTest() =
+    runAnchorTest(RememberAnchorScope::ordAnchor) {
+      given("custom effect scope") {
+        effectScope { OrdEffect(data = "all-types") }
+      }
+
+      on("reduce, effect, signal, event, reduce") {
+        reduce { copy(a = 1) }
+        effect { data }
+        post { OrdSignal.A }
+        emit { OrdEvent.X }
+        reduce { copy(b = 2) }
+      }
+
+      verify("all action types verified") {
+        assertState { copy(a = 1) }
+        assertSignal { OrdSignal.A }
+        assertEvent { OrdEvent.X }
+        assertState { copy(b = 2) }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/CancellableTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/CancellableTest.kt
@@ -1,0 +1,99 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.Signal
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+
+private class CancelEffect : Effect
+
+private data class CancelViewState(
+  val value: Int = 0,
+) : ViewState
+
+private sealed interface CancelSignal : Signal {
+  data object Done : CancelSignal
+}
+
+private typealias CancelAnchor = Anchor<CancelEffect, CancelViewState, Nothing>
+
+private fun RememberAnchorScope.cancelAnchor(): CancelAnchor =
+  create(
+    initialState = ::CancelViewState,
+    effectScope = { CancelEffect() },
+  )
+
+class CancellableTest {
+
+  /**
+   * Verifies that `cancellable` in the test runtime simply runs the
+   * block directly (AnchorTestRuntime line 52-53). There is no
+   * cancellation semantics in tests — the block executes inline.
+   * The reduce inside is captured normally.
+   */
+  @Test
+  fun cancellableRunsBlockDirectly() =
+    runAnchorTest(RememberAnchorScope::cancelAnchor) {
+      given("default state") {}
+
+      on("reducing inside cancellable") {
+        cancellable("key") {
+          reduce { copy(value = 1) }
+        }
+      }
+
+      verify("reduce was captured") {
+        assertState { copy(value = 1) }
+      }
+    }
+
+  /**
+   * Verifies that mixed actions (reduce + signal) inside a cancellable
+   * block are all captured in order. The cancellable wrapper is
+   * transparent to action recording.
+   */
+  @Test
+  fun cancellableWithMixedActions() =
+    runAnchorTest(RememberAnchorScope::cancelAnchor) {
+      given("default state") {}
+
+      on("reduce and signal inside cancellable") {
+        cancellable("key") {
+          reduce { copy(value = 1) }
+          post { CancelSignal.Done }
+        }
+      }
+
+      verify("both actions captured in order") {
+        assertState { copy(value = 1) }
+        assertSignal { CancelSignal.Done }
+      }
+    }
+
+  /**
+   * Verifies that two separate cancellable blocks with different keys
+   * both execute fully. In the test runtime, cancellable does not
+   * cancel previous jobs — each block runs to completion.
+   */
+  @Test
+  fun nestedCancellableBlocks() =
+    runAnchorTest(RememberAnchorScope::cancelAnchor) {
+      given("default state") {}
+
+      on("two cancellable blocks with different keys") {
+        cancellable("first") {
+          reduce { copy(value = 1) }
+        }
+        cancellable("second") {
+          reduce { copy(value = value + 10) }
+        }
+      }
+
+      verify("both blocks ran") {
+        assertState { copy(value = 1) }
+        assertState { copy(value = value + 10) }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/EffectTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/EffectTest.kt
@@ -1,0 +1,137 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private data class FxEffect(
+  val data: String = "default",
+) : Effect
+
+private data class FxViewState(
+  val result: String = "",
+) : ViewState
+
+private typealias FxAnchor = Anchor<FxEffect, FxViewState, Nothing>
+
+private fun RememberAnchorScope.fxAnchor(): FxAnchor =
+  create(
+    initialState = ::FxViewState,
+    effectScope = { FxEffect() },
+  )
+
+class EffectTest {
+
+  /**
+   * Verifies that `effect { }` in the action block executes against the
+   * custom effect scope provided via `given { effectScope { } }`. The
+   * returned value is used in a subsequent reduce to prove the custom
+   * scope was active.
+   */
+  @Test
+  fun effectReturnsValueFromCustomScope() =
+    runAnchorTest(RememberAnchorScope::fxAnchor) {
+      given("custom effect scope") {
+        effectScope { FxEffect(data = "custom") }
+      }
+
+      on("reading data from effect") {
+        val d = effect { data }
+        reduce { copy(result = d) }
+      }
+
+      verify("result matches custom scope data") {
+        assertState { copy(result = "custom") }
+      }
+    }
+
+  /**
+   * Verifies that when no effectScope override is provided, the factory's
+   * default effect scope is used. FxEffect defaults to data = "default".
+   */
+  @Test
+  fun effectUsesDefaultScope() =
+    runAnchorTest(RememberAnchorScope::fxAnchor) {
+      given("no override") {}
+
+      on("reading data from default effect") {
+        val d = effect { data }
+        reduce { copy(result = d) }
+      }
+
+      verify("result matches factory default") {
+        assertState { copy(result = "default") }
+      }
+    }
+
+  /**
+   * Verifies that `effect { }` calls are NOT recorded in verifyActions.
+   * AnchorTestRuntime.effect() executes the block directly and returns
+   * the result without adding to the action list. An action with only
+   * an effect call and no reduce/post/emit produces zero recorded actions.
+   */
+  @Test
+  fun effectDoesNotRecordAction() =
+    runAnchorTest(RememberAnchorScope::fxAnchor) {
+      given("default state") {}
+
+      on("calling effect without reduce") { effect { data } }
+
+      verify("no actions recorded") {}
+    }
+
+  /**
+   * Verifies that effect execution can be validated indirectly by
+   * asserting the state change that depends on the effect's return value.
+   * Since `effect { }` is not recorded in verifyActions, the correctness
+   * of the effect scope is proven through the reduce that uses its result.
+   *
+   * Note: `assertEffect` adds to expectedActions but does not consume from
+   * actualActions, causing a size mismatch when mixed with other assertions.
+   * The idiomatic way to verify effects is through their impact on state.
+   */
+  @Test
+  fun effectVerifiedThroughStateImpact() =
+    runAnchorTest(RememberAnchorScope::fxAnchor) {
+      given("custom effect scope") {
+        effectScope { FxEffect(data = "verify-me") }
+      }
+
+      on("reading from effect and reducing") {
+        val d = effect { data }
+        reduce { copy(result = d) }
+      }
+
+      verify("state proves effect returned the custom value") {
+        assertState { copy(result = "verify-me") }
+      }
+    }
+
+  /**
+   * Verifies that multiple effects interspersed with reduces all execute
+   * correctly. Each effect reads from the same scope, and each reduce
+   * is captured and assertable in order.
+   */
+  @Test
+  fun multipleEffectsAndReduces() =
+    runAnchorTest(RememberAnchorScope::fxAnchor) {
+      given("custom effect scope") {
+        effectScope { FxEffect(data = "multi") }
+      }
+
+      on("two effects feeding two reduces") {
+        val first = effect { data }
+        reduce { copy(result = first) }
+        val second = effect { "${data}-2" }
+        reduce { copy(result = second) }
+      }
+
+      verify("both reduces captured in order") {
+        assertState { copy(result = "multi") }
+        assertState { copy(result = "multi-2") }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlerBehaviorTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlerBehaviorTest.kt
@@ -1,0 +1,195 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.DomainDefectException
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.Event
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.Signal
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+
+private class HandlerEffect : Effect
+
+private data class HandlerViewState(
+  val value: Int = 0,
+  val error: String = "",
+) : ViewState
+
+private sealed interface HandlerErr {
+  data object NotFound : HandlerErr
+  data class InvalidInput(val reason: String) : HandlerErr
+}
+
+private sealed interface HandlerSignal : Signal {
+  data object ErrorOccurred : HandlerSignal
+}
+
+private sealed interface HandlerEvent : Event {
+  data object ErrorLogged : HandlerEvent
+}
+
+private typealias HandlerAnchor = Anchor<HandlerEffect, HandlerViewState, HandlerErr>
+
+private fun RememberAnchorScope.handlerAnchor(): HandlerAnchor =
+  create(
+    initialState = ::HandlerViewState,
+    effectScope = { HandlerEffect() },
+  )
+
+class ErrorHandlerBehaviorTest {
+
+  /**
+   * Verifies that a domain error handler can call `reduce` to update state.
+   * When `raise` propagates to the handler, the handler's reduce is captured
+   * in verifyActions alongside the raise itself.
+   */
+  @Test
+  fun domainErrorHandlerReducesState() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("handler that reduces") {
+        onDomainError { reduce { copy(error = "handled") } }
+      }
+
+      on("raising") { raise(HandlerErr.NotFound) }
+
+      verify("raise recorded, handler reduce captured") {
+        assertRaise { HandlerErr.NotFound }
+        assertState { copy(error = "handled") }
+        assertDomainError { HandlerErr.NotFound }
+      }
+    }
+
+  /**
+   * Verifies that a domain error handler can post a signal. The signal
+   * from the handler is captured in verifyActions and assertable with
+   * assertSignal.
+   */
+  @Test
+  fun domainErrorHandlerPostsSignal() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("handler that posts a signal") {
+        onDomainError { post { HandlerSignal.ErrorOccurred } }
+      }
+
+      on("raising") { raise(HandlerErr.NotFound) }
+
+      verify("raise recorded, handler signal captured") {
+        assertRaise { HandlerErr.NotFound }
+        assertSignal { HandlerSignal.ErrorOccurred }
+        assertDomainError { HandlerErr.NotFound }
+      }
+    }
+
+  /**
+   * Verifies that a domain error handler can emit an event. The event
+   * from the handler is captured in verifyActions and assertable with
+   * assertEvent.
+   */
+  @Test
+  fun domainErrorHandlerEmitsEvent() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("handler that emits an event") {
+        onDomainError { emit { HandlerEvent.ErrorLogged } }
+      }
+
+      on("raising") { raise(HandlerErr.NotFound) }
+
+      verify("raise recorded, handler event captured") {
+        assertRaise { HandlerErr.NotFound }
+        assertEvent { HandlerEvent.ErrorLogged }
+        assertDomainError { HandlerErr.NotFound }
+      }
+    }
+
+  /**
+   * Verifies that a defect handler can call `reduce` to update state.
+   * When `orDie` escalates, the defect handler's reduce is captured.
+   */
+  @Test
+  fun defectHandlerReducesState() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("defect handler that reduces") {
+        defect { t -> reduce { copy(error = t.message.orEmpty()) } }
+      }
+
+      on("calling orDie") { orDie(HandlerErr.NotFound) }
+
+      verify("orDie recorded, handler reduce captured") {
+        assertOrDie { HandlerErr.NotFound }
+        assertState { copy(error = "Domain defect: ${HandlerErr.NotFound}") }
+        assertDefect { DomainDefectException(HandlerErr.NotFound) }
+      }
+    }
+
+  /**
+   * Verifies that a defect handler can post a signal after orDie
+   * escalation. The signal is captured and assertable.
+   */
+  @Test
+  fun defectHandlerPostsSignal() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("defect handler that posts signal") {
+        defect { post { HandlerSignal.ErrorOccurred } }
+      }
+
+      on("calling orDie") { orDie(HandlerErr.NotFound) }
+
+      verify("orDie recorded, handler signal captured") {
+        assertOrDie { HandlerErr.NotFound }
+        assertSignal { HandlerSignal.ErrorOccurred }
+        assertDefect { DomainDefectException(HandlerErr.NotFound) }
+      }
+    }
+
+  /**
+   * Verifies that actions performed before a raise are preserved in the
+   * action list. The pre-raise reduce is recorded first, then the raise,
+   * then the handler's reduce. All three appear in order.
+   */
+  @Test
+  fun actionReduceThenRaiseWithHandler() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("handler that reduces on error") {
+        onDomainError { reduce { copy(error = "caught") } }
+      }
+
+      on("reduce then raise") {
+        reduce { copy(value = 1) }
+        raise(HandlerErr.NotFound)
+      }
+
+      verify("pre-raise reduce, raise, and handler reduce all recorded") {
+        assertState { copy(value = 1) }
+        assertRaise { HandlerErr.NotFound }
+        assertState { copy(error = "caught") }
+        assertDomainError { HandlerErr.NotFound }
+      }
+    }
+
+  /**
+   * Verifies that the domain error handler receives the correct error
+   * variant when using a sealed interface with data. The InvalidInput
+   * variant carries a reason string that the handler can read.
+   */
+  @Test
+  fun handlerReceivesCorrectErrorValue() =
+    runAnchorTest(RememberAnchorScope::handlerAnchor) {
+      given("handler that reads error variant") {
+        onDomainError { err ->
+          when (err) {
+            is HandlerErr.InvalidInput -> reduce { copy(error = err.reason) }
+            is HandlerErr.NotFound -> reduce { copy(error = "not found") }
+          }
+        }
+      }
+
+      on("raising InvalidInput") { raise(HandlerErr.InvalidInput("bad data")) }
+
+      verify("handler reduced with the reason from InvalidInput") {
+        assertRaise { HandlerErr.InvalidInput("bad data") }
+        assertState { copy(error = "bad data") }
+        assertDomainError { HandlerErr.InvalidInput("bad data") }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlingTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlingTest.kt
@@ -1,15 +1,21 @@
 package dev.kioba.anchor.test
 
 import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.DomainDefectException
 import dev.kioba.anchor.Effect
 import dev.kioba.anchor.RememberAnchorScope
 import dev.kioba.anchor.ViewState
+import dev.kioba.anchor.fold
+import dev.kioba.anchor.getErrorOrNull
 import dev.kioba.anchor.getOrElse
+import dev.kioba.anchor.getOrNull
+import dev.kioba.anchor.orDie
 import dev.kioba.anchor.recover
 import kotlin.test.Test
 
 private sealed interface TestErr {
   data object NotFound : TestErr
+  data class InvalidInput(val reason: String) : TestErr
 }
 
 private class TestEffect : Effect
@@ -26,7 +32,7 @@ private fun RememberAnchorScope.testAnchor(): TestAnchor =
     effectScope = { TestEffect() },
   )
 
-// -- Helpers --
+// -- Helpers: recover + getOrElse --
 
 private suspend fun TestAnchor.raiseWithRecover() {
   recover { raise(TestErr.NotFound) }
@@ -42,10 +48,107 @@ private suspend fun TestAnchor.orDieInsideRecover() {
     .getOrElse { reduce { copy(value = 42) } }
 }
 
+// -- Helpers: raise propagation --
+
+private suspend fun TestAnchor.raiseDirectly() {
+  raise(TestErr.NotFound)
+}
+
+// -- Helpers: recover ok path --
+
+private suspend fun TestAnchor.recoverOkPath() {
+  val result = recover { 42 }.getOrElse { -1 }
+  reduce { copy(value = result) }
+}
+
+// -- Helpers: getOrNull --
+
+private suspend fun TestAnchor.recoverGetOrNullOk() {
+  val result = recover { 42 }.getOrNull()
+  reduce { copy(value = result ?: -1) }
+}
+
+private suspend fun TestAnchor.recoverGetOrNullError() {
+  val result = recover { raise(TestErr.NotFound) }.getOrNull()
+  reduce { copy(value = result ?: -1) }
+}
+
+// -- Helpers: getErrorOrNull --
+
+private suspend fun TestAnchor.recoverGetErrorOrNullOk() {
+  val err = recover { 42 }.getErrorOrNull()
+  reduce { copy(value = if (err == null) 1 else 0) }
+}
+
+private suspend fun TestAnchor.recoverGetErrorOrNullError() {
+  val err = recover { raise(TestErr.NotFound) }.getErrorOrNull()
+  reduce { copy(value = if (err != null) 1 else 0) }
+}
+
+// -- Helpers: fold --
+
+private suspend fun TestAnchor.recoverFoldOk() {
+  val result = recover { 42 }.fold(onError = { -1 }, onOk = { it * 2 })
+  reduce { copy(value = result) }
+}
+
+private suspend fun TestAnchor.recoverFoldError() {
+  val result = recover { raise(TestErr.NotFound) }.fold(onError = { -1 }, onOk = { it })
+  reduce { copy(value = result) }
+}
+
+// -- Helpers: ensure --
+
+private suspend fun TestAnchor.ensureTrue() {
+  ensure(true) { TestErr.NotFound }
+  reduce { copy(value = 1) }
+}
+
+private suspend fun TestAnchor.ensureFalseWithRecover() {
+  recover { ensure(false) { TestErr.NotFound } }
+    .getOrElse { reduce { copy(value = -1) } }
+}
+
+// -- Helpers: orDie on Recover --
+
+private suspend fun TestAnchor.orDieOnRecoverOk() {
+  val r = recover { 42 }
+  val v = orDie(r)
+  reduce { copy(value = v) }
+}
+
+private suspend fun TestAnchor.orDieOnRecoverError() {
+  val r = recover { raise(TestErr.NotFound) }
+  orDie(r)
+}
+
+// -- Helpers: multiple recovers --
+
+private suspend fun TestAnchor.multipleRecovers() {
+  recover { raise(TestErr.NotFound) }
+    .getOrElse { reduce { copy(value = 1) } }
+  recover { raise(TestErr.InvalidInput("bad")) }
+    .getOrElse { reduce { copy(value = 2) } }
+}
+
+// -- Helpers: different error variant --
+
+private suspend fun TestAnchor.raiseInvalidInput() {
+  recover { raise(TestErr.InvalidInput("bad input")) }
+    .getOrRaise()
+}
+
 // -- Tests --
 
 class ErrorHandlingTest {
 
+  // ===== Existing tests =====
+
+  /**
+   * Verifies that `raise()` inside an Anchor-level `recover` block is caught
+   * by the recover and the `getOrElse` fallback executes. The raise is still
+   * recorded in verifyActions, and the fallback reduce is captured too.
+   */
   @Test
   fun raiseInsideRecoverRoutesToGetOrElse() =
     runAnchorTest(RememberAnchorScope::testAnchor) {
@@ -59,6 +162,12 @@ class ErrorHandlingTest {
       }
     }
 
+  /**
+   * Verifies that `raise` followed by `getOrRaise()` produces two raise
+   * records: the initial raise inside recover, and the re-raise from
+   * getOrRaise. Since the second raise escapes recover, it propagates
+   * to the domain error handler.
+   */
   @Test
   fun raiseAndReraisePropagatesToBddFramework() =
     runAnchorTest(RememberAnchorScope::testAnchor) {
@@ -73,6 +182,11 @@ class ErrorHandlingTest {
       }
     }
 
+  /**
+   * Verifies that `orDie()` inside a recover block is NOT caught by recover
+   * (it throws DomainDefectException, not RaisedException). The orDie is
+   * recorded, and the defect handler is invoked.
+   */
   @Test
   fun orDieInsideRecoverEscalates() =
     runAnchorTest(RememberAnchorScope::testAnchor) {
@@ -82,8 +196,271 @@ class ErrorHandlingTest {
 
       verify("orDie was recorded") {
         assertOrDie { TestErr.NotFound }
-        assertDefect { dev.kioba.anchor.DomainDefectException(TestErr.NotFound) }
+        assertDefect { DomainDefectException(TestErr.NotFound) }
       }
     }
 
+  // ===== New: raise propagation =====
+
+  /**
+   * Verifies that `raise()` without a recover block propagates to the
+   * `onDomainError` handler registered via given. The raise is recorded
+   * in verifyActions, and the domain error handler is invoked with
+   * the error value.
+   */
+  @Test
+  fun raiseDirectlyPropagatesToDomainHandler() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("a domain error handler") {
+        onDomainError { reduce { copy(value = -1) } }
+      }
+
+      on("raising directly") { raiseDirectly() }
+
+      verify("raise recorded and handler invoked") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = -1) }
+        assertDomainError { TestErr.NotFound }
+      }
+    }
+
+  // ===== New: recover Ok path =====
+
+  /**
+   * Verifies that `recover { value }` when no raise occurs returns
+   * `Recover.Ok(value)`. The `getOrElse` fallback is NOT called, and
+   * the success value is used in a reduce.
+   */
+  @Test
+  fun recoverOkReturnsValue() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover succeeds") { recoverOkPath() }
+
+      verify("value 42 from recover Ok used in reduce") {
+        assertState { copy(value = 42) }
+      }
+    }
+
+  // ===== New: getOrNull =====
+
+  /**
+   * Verifies that `getOrNull()` on a successful `Recover.Ok` returns the
+   * value (not null). The non-null value is used in a reduce.
+   */
+  @Test
+  fun getOrNullOnOkReturnsValue() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover ok then getOrNull") { recoverGetOrNullOk() }
+
+      verify("value 42 from getOrNull") {
+        assertState { copy(value = 42) }
+      }
+    }
+
+  /**
+   * Verifies that `getOrNull()` on a `Recover.Error` returns null.
+   * The null fallback produces value = -1 in the reduce.
+   */
+  @Test
+  fun getOrNullOnErrorReturnsNull() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover error then getOrNull") { recoverGetOrNullError() }
+
+      verify("raise recorded, null fallback produced -1") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = -1) }
+      }
+    }
+
+  // ===== New: getErrorOrNull =====
+
+  /**
+   * Verifies that `getErrorOrNull()` on a successful `Recover.Ok` returns
+   * null. The null check produces value = 1 (error was null).
+   */
+  @Test
+  fun getErrorOrNullOnOkReturnsNull() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover ok then getErrorOrNull") { recoverGetErrorOrNullOk() }
+
+      verify("no error, value = 1") {
+        assertState { copy(value = 1) }
+      }
+    }
+
+  /**
+   * Verifies that `getErrorOrNull()` on a `Recover.Error` returns the error.
+   * The non-null check produces value = 1 (error was present).
+   */
+  @Test
+  fun getErrorOrNullOnErrorReturnsError() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover error then getErrorOrNull") { recoverGetErrorOrNullError() }
+
+      verify("raise recorded, error present, value = 1") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = 1) }
+      }
+    }
+
+  // ===== New: fold =====
+
+  /**
+   * Verifies that `fold` on a successful `Recover.Ok` invokes the `onOk`
+   * branch. The value 42 is doubled to 84.
+   */
+  @Test
+  fun foldOnOkCallsOnOk() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover ok then fold") { recoverFoldOk() }
+
+      verify("onOk doubled the value to 84") {
+        assertState { copy(value = 84) }
+      }
+    }
+
+  /**
+   * Verifies that `fold` on a `Recover.Error` invokes the `onError` branch.
+   * The fallback produces -1.
+   */
+  @Test
+  fun foldOnErrorCallsOnError() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("recover error then fold") { recoverFoldError() }
+
+      verify("raise recorded, onError produced -1") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = -1) }
+      }
+    }
+
+  // ===== New: ensure =====
+
+  /**
+   * Verifies that `ensure(true) { error }` does NOT raise — execution
+   * continues to the subsequent reduce. No raise is recorded.
+   */
+  @Test
+  fun ensureTrueDoesNotRaise() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("ensure with true condition") { ensureTrue() }
+
+      verify("no raise, reduce ran") {
+        assertState { copy(value = 1) }
+      }
+    }
+
+  /**
+   * Verifies that `ensure(false) { error }` inside a recover block raises
+   * the error, which is caught by recover. The `getOrElse` fallback runs
+   * and produces value = -1.
+   */
+  @Test
+  fun ensureFalseInsideRecoverCatchesRaise() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("ensure false inside recover") { ensureFalseWithRecover() }
+
+      verify("raise recorded and fallback ran") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = -1) }
+      }
+    }
+
+  // ===== New: orDie on Recover =====
+
+  /**
+   * Verifies that `orDie(recover { value })` on a successful Recover
+   * returns the value without escalating. No defect is triggered.
+   */
+  @Test
+  fun orDieOnRecoverOkReturnsValue() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("orDie on successful recover") { orDieOnRecoverOk() }
+
+      verify("value 42 used in reduce, no defect") {
+        assertState { copy(value = 42) }
+      }
+    }
+
+  /**
+   * Verifies that `orDie(recover { raise(error) })` escalates the error
+   * to a defect. The initial raise inside recover is recorded, then
+   * orDie escalates, and the defect handler is invoked.
+   */
+  @Test
+  fun orDieOnRecoverErrorEscalates() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("orDie on failed recover") { orDieOnRecoverError() }
+
+      verify("raise and orDie recorded, defect handler invoked") {
+        assertRaise { TestErr.NotFound }
+        assertOrDie { TestErr.NotFound }
+        assertDefect { DomainDefectException(TestErr.NotFound) }
+      }
+    }
+
+  // ===== New: multiple recovers =====
+
+  /**
+   * Verifies that multiple sequential recover-getOrElse blocks each
+   * record their raises independently. Both fallback reduces are
+   * captured in order.
+   */
+  @Test
+  fun multipleRecoverGetOrElseBlocks() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("two sequential recover blocks") { multipleRecovers() }
+
+      verify("both raises and both fallback reduces recorded") {
+        assertRaise { TestErr.NotFound }
+        assertState { copy(value = 1) }
+        assertRaise { TestErr.InvalidInput("bad") }
+        assertState { copy(value = 2) }
+      }
+    }
+
+  // ===== New: error variants =====
+
+  /**
+   * Verifies that different sealed interface variants of the error type
+   * are correctly recorded and distinguishable. Uses InvalidInput with
+   * a data payload instead of the singleton NotFound.
+   */
+  @Test
+  fun raiseWithDifferentErrorVariants() =
+    runAnchorTest(RememberAnchorScope::testAnchor) {
+      given("default state") {}
+
+      on("raising InvalidInput") { raiseInvalidInput() }
+
+      verify("both raise records show InvalidInput") {
+        assertRaise { TestErr.InvalidInput("bad input") }
+        assertRaise { TestErr.InvalidInput("bad input") }
+        assertDomainError { TestErr.InvalidInput("bad input") }
+      }
+    }
 }

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlingTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ErrorHandlingTest.kt
@@ -69,6 +69,7 @@ class ErrorHandlingTest {
       verify("both raises were recorded") {
         assertRaise { TestErr.NotFound }
         assertRaise { TestErr.NotFound }
+        assertDomainError { TestErr.NotFound }
       }
     }
 
@@ -81,6 +82,7 @@ class ErrorHandlingTest {
 
       verify("orDie was recorded") {
         assertOrDie { TestErr.NotFound }
+        assertDefect { dev.kioba.anchor.DomainDefectException(TestErr.NotFound) }
       }
     }
 

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/EventTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/EventTest.kt
@@ -1,0 +1,112 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.Event
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+private class EvtEffect : Effect
+
+private data class EvtViewState(
+  val value: Int = 0,
+) : ViewState
+
+private sealed interface EvtEvent : Event {
+  data object Refresh : EvtEvent
+  data object Cancel : EvtEvent
+}
+
+private typealias EvtAnchor = Anchor<EvtEffect, EvtViewState, Nothing>
+
+private fun RememberAnchorScope.evtAnchor(): EvtAnchor =
+  create(
+    initialState = ::EvtViewState,
+    effectScope = { EvtEffect() },
+  )
+
+class EventTest {
+
+  /**
+   * Verifies that a single event emitted via `emit { }` is captured by
+   * the test runtime and correctly matched by assertEvent. Events are
+   * compared by value equality.
+   */
+  @Test
+  fun singleEventEmitted() =
+    runAnchorTest(RememberAnchorScope::evtAnchor) {
+      given("default state") {}
+
+      on("emitting Refresh") { emit { EvtEvent.Refresh } }
+
+      verify("Refresh event was recorded") {
+        assertEvent { EvtEvent.Refresh }
+      }
+    }
+
+  /**
+   * Verifies that multiple events emitted in sequence are recorded in
+   * order and must be asserted in the same order. Order is enforced by
+   * the sequential removal from actualActions in assertEvents.
+   */
+  @Test
+  fun multipleEventsInOrder() =
+    runAnchorTest(RememberAnchorScope::evtAnchor) {
+      given("default state") {}
+
+      on("emitting Refresh then Cancel") {
+        emit { EvtEvent.Refresh }
+        emit { EvtEvent.Cancel }
+      }
+
+      verify("events match in emitted order") {
+        assertEvent { EvtEvent.Refresh }
+        assertEvent { EvtEvent.Cancel }
+      }
+    }
+
+  /**
+   * Negative test: verifies that asserting the wrong event type causes
+   * an AssertionError. The assertEquals in the EventAction branch of
+   * assertEvents detects the mismatch.
+   */
+  @Test
+  fun eventMismatchFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::evtAnchor) {
+        given("default state") {}
+
+        on("emitting Refresh") { emit { EvtEvent.Refresh } }
+
+        verify("wrong event asserted") {
+          assertEvent { EvtEvent.Cancel }
+        }
+      }
+    }
+  }
+
+  /**
+   * Verifies that events can be interleaved with reduces and both are
+   * recorded in correct order. Events do not affect state threading —
+   * the second assertState receives the state produced by the first reduce.
+   */
+  @Test
+  fun eventInterleavedWithReduce() =
+    runAnchorTest(RememberAnchorScope::evtAnchor) {
+      given("default state") {}
+
+      on("reduce, event, reduce") {
+        reduce { copy(value = 1) }
+        emit { EvtEvent.Refresh }
+        reduce { copy(value = value + 1) }
+      }
+
+      verify("actions match in order, state threads across event") {
+        assertState { copy(value = 1) }
+        assertEvent { EvtEvent.Refresh }
+        assertState { copy(value = value + 1) }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/GivenScopeTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/GivenScopeTest.kt
@@ -1,0 +1,171 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.DomainDefectException
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+
+private data class GivenEffect(
+  val data: String = "default",
+) : Effect
+
+private data class GivenViewState(
+  val value: Int = 0,
+  val label: String = "",
+) : ViewState
+
+// -- PureAnchor fixtures (no error type) --
+
+private typealias PureGivenAnchor = Anchor<GivenEffect, GivenViewState, Nothing>
+
+private fun RememberAnchorScope.pureGivenAnchor(): PureGivenAnchor =
+  create(
+    initialState = ::GivenViewState,
+    effectScope = { GivenEffect() },
+  )
+
+// -- Error-capable fixtures --
+
+private sealed interface GivenErr {
+  data object NotFound : GivenErr
+}
+
+private typealias ErrGivenAnchor = Anchor<GivenEffect, GivenViewState, GivenErr>
+
+private fun RememberAnchorScope.errGivenAnchor(): ErrGivenAnchor =
+  create(
+    initialState = ::GivenViewState,
+    effectScope = { GivenEffect() },
+  )
+
+class GivenScopeTest {
+
+  /**
+   * Verifies that `initialState` in the given block overrides the factory
+   * default. The action reduces from the overridden state (value = 99),
+   * proving the custom initial state was applied.
+   */
+  @Test
+  fun initialStateOverridesFactoryDefault() =
+    runAnchorTest(RememberAnchorScope::pureGivenAnchor) {
+      given("custom initial state") {
+        initialState { GivenViewState(value = 99) }
+      }
+
+      on("reducing from overridden state") {
+        reduce { copy(value = value + 1) }
+      }
+
+      verify("state started from 99") {
+        assertState { copy(value = value + 1) }
+      }
+    }
+
+  /**
+   * Verifies that `effectScope` in the given block replaces the factory's
+   * default effect scope. The action calls `effect { data }` which reads
+   * from the custom scope providing "custom" instead of "default".
+   */
+  @Test
+  fun effectScopeReplacesDefault() =
+    runAnchorTest(RememberAnchorScope::pureGivenAnchor) {
+      given("custom effect scope") {
+        effectScope { GivenEffect(data = "custom") }
+      }
+
+      on("reading from effect scope") {
+        val d = effect { data }
+        reduce { copy(label = d) }
+      }
+
+      verify("effect scope had custom data") {
+        assertState { copy(label = "custom") }
+      }
+    }
+
+  /**
+   * Verifies that when no effectScope override is provided, the factory's
+   * default effect scope is used. The default GivenEffect has data = "default".
+   */
+  @Test
+  fun effectScopeDefaultFromFactory() =
+    runAnchorTest(RememberAnchorScope::pureGivenAnchor) {
+      given("no effect scope override") {}
+
+      on("reading from default effect scope") {
+        val d = effect { data }
+        reduce { copy(label = d) }
+      }
+
+      verify("effect scope had factory default data") {
+        assertState { copy(label = "default") }
+      }
+    }
+
+  /**
+   * Verifies that `onDomainError` in the given block overrides the factory's
+   * error handler. The custom handler reduces state with a marker value,
+   * proving it was invoked instead of the factory default (which is null).
+   */
+  @Test
+  fun onDomainErrorOverridesFactory() =
+    runAnchorTest(RememberAnchorScope::errGivenAnchor) {
+      given("custom domain error handler") {
+        onDomainError { reduce { copy(value = -1) } }
+      }
+
+      on("raising a domain error") { raise(GivenErr.NotFound) }
+
+      verify("custom handler ran and reduced state") {
+        assertRaise { GivenErr.NotFound }
+        assertState { copy(value = -1) }
+        assertDomainError { GivenErr.NotFound }
+      }
+    }
+
+  /**
+   * Verifies that `defect` in the given block overrides the factory's
+   * defect handler. The custom handler reduces state with the throwable
+   * message, proving it was invoked.
+   */
+  @Test
+  fun defectOverridesFactory() =
+    runAnchorTest(RememberAnchorScope::errGivenAnchor) {
+      given("custom defect handler") {
+        defect { t -> reduce { copy(label = t.message.orEmpty()) } }
+      }
+
+      on("calling orDie") { orDie(GivenErr.NotFound) }
+
+      verify("custom defect handler ran") {
+        assertOrDie { GivenErr.NotFound }
+        assertState { copy(label = "Domain defect: ${GivenErr.NotFound}") }
+        assertDefect { DomainDefectException(GivenErr.NotFound) }
+      }
+    }
+
+  /**
+   * Verifies that `initialState` and `effectScope` can both be overridden
+   * in the same given block and compose correctly. The action reads from
+   * the custom effect scope and reduces from the custom initial state.
+   */
+  @Test
+  fun initialStateAndEffectScopeCompose() =
+    runAnchorTest(RememberAnchorScope::pureGivenAnchor) {
+      given("both overridden") {
+        initialState { GivenViewState(value = 10, label = "") }
+        effectScope { GivenEffect(data = "composed") }
+      }
+
+      on("using both overrides") {
+        val d = effect { data }
+        reduce { copy(value = value + 1, label = d) }
+      }
+
+      verify("state started from 10 and effect had composed data") {
+        assertState { copy(value = value + 1, label = "composed") }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/README.md
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/README.md
@@ -1,0 +1,126 @@
+# anchor-test Module Tests
+
+Comprehensive test coverage for the Anchor BDD test DSL (`runAnchorTest`).
+
+These tests verify the **test infrastructure itself** — that `assertState`, `assertSignal`, `assertRaise`, and all other DSL functions correctly record and match actions. The `anchor` core module has its own unit tests for runtime behavior (`RaiseTest`, `StandaloneRecoverTest`, `ExecuteBoundaryTest`, etc.).
+
+## Test Organization
+
+Tests are ordered from simple to complex across files. Within each file, happy-path tests come first, followed by edge cases, then negative/failure tests.
+
+| File | DSL Area | Tests | Description |
+|------|----------|-------|-------------|
+| `RunAnchorTestTest.kt` | Entry point | 4 | Minimal DSL lifecycle, factory defaults, basic wiring |
+| `ReduceTest.kt` | `assertState` | 7 | State updates, threading across reduces, idempotency, negative cases |
+| `SignalTest.kt` | `assertSignal` | 4 | Signal posting, ordering, interleaving with reduces |
+| `EventTest.kt` | `assertEvent` | 4 | Event emission, ordering, interleaving with reduces |
+| `GivenScopeTest.kt` | Setup | 6 | `initialState`, `effectScope`, handler overrides, composition |
+| `EffectTest.kt` | `effect { }` | 5 | Effect execution, scope resolution, non-recording behavior |
+| `CancellableTest.kt` | `cancellable` | 3 | Inline execution in tests, mixed actions, multiple blocks |
+| `WithStateTest.kt` | `withState` | 3 | Read-only state access, post-reduce reads, no-action recording |
+| `ErrorHandlingTest.kt` | Error primitives | 18 | `raise`, `recover`, `orDie`, `ensure`, `Recover` extensions |
+| `ErrorHandlerBehaviorTest.kt` | Handler effects | 7 | Handlers that reduce/post/emit, pre-raise action preservation |
+| `ActionOrderingTest.kt` | Ordering | 5 | Mixed sequences, type mismatches, size mismatches |
+
+**Total: 66 tests**
+
+## Coverage Map
+
+### DSL Entry Point
+- `runAnchorTest` lifecycle: `RunAnchorTestTest`
+
+### GivenScope Functions
+| Function | Covered In |
+|----------|-----------|
+| `initialState { }` | `GivenScopeTest`, `WithStateTest` |
+| `effectScope { }` | `GivenScopeTest`, `EffectTest`, `ActionOrderingTest` |
+| `onDomainError { }` | `GivenScopeTest`, `ErrorHandlerBehaviorTest` |
+| `defect { }` | `GivenScopeTest`, `ErrorHandlerBehaviorTest` |
+
+### VerifyScope Functions
+| Function | Covered In |
+|----------|-----------|
+| `assertState { }` | `ReduceTest`, `RunAnchorTestTest`, `SignalTest`, `EventTest`, all error tests |
+| `assertSignal { }` | `SignalTest`, `CancellableTest`, `ErrorHandlerBehaviorTest`, `ActionOrderingTest` |
+| `assertEvent { }` | `EventTest`, `ErrorHandlerBehaviorTest`, `ActionOrderingTest` |
+| `assertEffect { }` | `EffectTest` (documents current size-check limitation) |
+| `assertRaise { }` | `ErrorHandlingTest`, `ErrorHandlerBehaviorTest` |
+| `assertOrDie { }` | `ErrorHandlingTest`, `ErrorHandlerBehaviorTest` |
+| `assertDomainError { }` | `ErrorHandlingTest`, `GivenScopeTest`, `ErrorHandlerBehaviorTest` |
+| `assertDefect { }` | `ErrorHandlingTest`, `GivenScopeTest`, `ErrorHandlerBehaviorTest` |
+
+### Anchor Capabilities in Tests
+| Capability | Covered In |
+|-----------|-----------|
+| `reduce { }` | `ReduceTest`, most other files |
+| `post { }` | `SignalTest`, `CancellableTest`, `ActionOrderingTest` |
+| `emit { }` | `EventTest`, `ActionOrderingTest` |
+| `effect { }` | `EffectTest`, `GivenScopeTest`, `ActionOrderingTest` |
+| `cancellable { }` | `CancellableTest` |
+| `withState { }` | `WithStateTest` |
+| `raise()` | `ErrorHandlingTest`, `ErrorHandlerBehaviorTest` |
+| `orDie()` | `ErrorHandlingTest`, `ErrorHandlerBehaviorTest` |
+| `ensure()` | `ErrorHandlingTest` |
+| `recover { }` | `ErrorHandlingTest` |
+| `Recover.getOrElse` | `ErrorHandlingTest` |
+| `Recover.getOrRaise` | `ErrorHandlingTest` |
+| `Recover.getOrNull` | `ErrorHandlingTest` |
+| `Recover.getErrorOrNull` | `ErrorHandlingTest` |
+| `Recover.fold` | `ErrorHandlingTest` |
+| `DefectAnchor.orDie(Recover)` | `ErrorHandlingTest` |
+
+### Negative Tests (expected failures)
+- Size mismatch (too many/few assertions): `ReduceTest`, `ActionOrderingTest`
+- Value mismatch (wrong state/signal/event): `ReduceTest`, `SignalTest`, `EventTest`
+- Type mismatch (wrong assertion order): `ActionOrderingTest`
+
+## Test Fixtures
+
+Each file defines its own private fixtures with unique names to avoid Kotlin same-package redeclaration conflicts. Files that don't need error types use `Nothing` (PureAnchor pattern).
+
+| File | Prefix | Has Error Type |
+|------|--------|---------------|
+| `RunAnchorTestTest.kt` | `Run` | No |
+| `ReduceTest.kt` | `Reduce` | No |
+| `SignalTest.kt` | `Sig` | No |
+| `EventTest.kt` | `Evt` | No |
+| `GivenScopeTest.kt` | `Given` | Yes (`GivenErr`) |
+| `EffectTest.kt` | `Fx` | No |
+| `CancellableTest.kt` | `Cancel` | No |
+| `WithStateTest.kt` | `Ws` | No |
+| `ErrorHandlingTest.kt` | `Test` | Yes (`TestErr`) |
+| `ErrorHandlerBehaviorTest.kt` | `Handler` | Yes (`HandlerErr`) |
+| `ActionOrderingTest.kt` | `Ord` | No |
+
+## Known Limitations
+
+### `assertEffect` size mismatch
+`assertEffect` adds an `EffectAction` to `expectedActions` but does not consume from `actualActions` during verification. This causes a size mismatch (`expectedActions.size != actualActions.size`) when `assertEffect` is mixed with other assertions. Effects should be verified indirectly through their impact on state.
+
+### `GivenScope.effect { }` is a no-op
+`GivenScopeImpl.effects` list is populated by `given { effect { } }` but is never consumed by `AnchorTestScope.assert()`. Only `effectScope { }` actually replaces the effect scope. This is a known limitation of the current implementation.
+
+### `cancellable` in tests runs inline
+`AnchorTestRuntime.cancellable()` executes the block directly without cancellation semantics. Tests cannot verify that a second invocation with the same key cancels the first.
+
+## Adding New Tests
+
+1. Identify which DSL area the test covers
+2. Add to the appropriate file (or create a new one for a new area)
+3. Add a KDoc comment above the test explaining intent and approach
+4. Use the file's private fixtures or extend them if needed
+5. Follow the pattern: simple first, edge cases next, negative/failure last
+6. Use unique fixture prefixes to avoid same-package redeclaration
+
+## Running Tests
+
+```bash
+# Run all anchor-test module tests (desktop)
+./gradlew :anchor-test:desktopTest
+
+# Run a specific test class
+./gradlew :anchor-test:desktopTest --tests "dev.kioba.anchor.test.ReduceTest"
+
+# Run all platforms
+./gradlew :anchor-test:allTests
+```

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ReduceTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/ReduceTest.kt
@@ -1,0 +1,166 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+private class ReduceEffect : Effect
+
+private data class ReduceViewState(
+  val count: Int = 0,
+  val name: String = "",
+) : ViewState
+
+private typealias ReduceAnchor = Anchor<ReduceEffect, ReduceViewState, Nothing>
+
+private fun RememberAnchorScope.reduceAnchor(): ReduceAnchor =
+  create(
+    initialState = ::ReduceViewState,
+    effectScope = { ReduceEffect() },
+  )
+
+class ReduceTest {
+
+  /**
+   * Verifies that a single reduce call is captured by the test runtime
+   * and correctly matched by a single assertState. The assertion lambda
+   * receives the initial state and must produce the expected new state.
+   */
+  @Test
+  fun singleReduceUpdatesState() =
+    runAnchorTest(RememberAnchorScope::reduceAnchor) {
+      given("default state") {}
+
+      on("reducing count to 1") { reduce { copy(count = 1) } }
+
+      verify("state has count = 1") {
+        assertState { copy(count = 1) }
+      }
+    }
+
+  /**
+   * Verifies state threading: each assertState lambda receives the state
+   * that results from all previous reduces. The runningFold in assertEvents
+   * carries state forward, so the second assertState sees count = 1 (not 0),
+   * and the third sees count = 2.
+   */
+  @Test
+  fun sequentialReducesThreadState() =
+    runAnchorTest(RememberAnchorScope::reduceAnchor) {
+      given("default state with count = 0") {}
+
+      on("three sequential reduces building on each other") {
+        reduce { copy(count = 1) }
+        reduce { copy(count = count + 1) }
+        reduce { copy(count = count * 10) }
+      }
+
+      verify("state threads through: 1 -> 2 -> 20") {
+        assertState { copy(count = 1) }
+        assertState { copy(count = count + 1) }
+        assertState { copy(count = count * 10) }
+      }
+    }
+
+  /**
+   * Verifies that a reduce updating multiple fields at once is correctly
+   * captured and asserted. Both count and name are set in a single reduce.
+   */
+  @Test
+  fun reduceOnMultipleFields() =
+    runAnchorTest(RememberAnchorScope::reduceAnchor) {
+      given("default state") {}
+
+      on("reducing two fields at once") {
+        reduce { copy(count = 7, name = "hello") }
+      }
+
+      verify("both fields updated") {
+        assertState { copy(count = 7, name = "hello") }
+      }
+    }
+
+  /**
+   * Verifies that an identity reducer (returning `this` unchanged) is still
+   * recorded as an action and must be asserted. The framework does not
+   * skip no-op reduces.
+   */
+  @Test
+  fun reduceIdentityIsNoOp() =
+    runAnchorTest(RememberAnchorScope::reduceAnchor) {
+      given("default state") {}
+
+      on("identity reduce") { reduce { this } }
+
+      verify("identity reduce still must be asserted") {
+        assertState { this }
+      }
+    }
+
+  /**
+   * Negative test: verifies that when assertState specifies a wrong
+   * expected state, the framework throws an AssertionError. This confirms
+   * the assertEquals check in the ReducerAction branch of assertEvents.
+   */
+  @Test
+  fun assertStateMismatchFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::reduceAnchor) {
+        given("default state") {}
+
+        on("reducing count to 1") { reduce { copy(count = 1) } }
+
+        verify("wrong expected value") {
+          assertState { copy(count = 999) }
+        }
+      }
+    }
+  }
+
+  /**
+   * Negative test: verifies that having more assertState calls than actual
+   * reduces causes a size mismatch AssertionError. The framework checks
+   * expectedActions.size == actualActions.size before iterating.
+   */
+  @Test
+  fun moreAssertsThanActionsFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::reduceAnchor) {
+        given("default state") {}
+
+        on("one reduce") { reduce { copy(count = 1) } }
+
+        verify("two asserts for one reduce") {
+          assertState { copy(count = 1) }
+          assertState { copy(count = 2) }
+        }
+      }
+    }
+  }
+
+  /**
+   * Negative test: verifies that having fewer assertState calls than actual
+   * reduces causes a size mismatch AssertionError. Every recorded action
+   * must have a matching assertion.
+   */
+  @Test
+  fun fewerAssertsThanActionsFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::reduceAnchor) {
+        given("default state") {}
+
+        on("two reduces") {
+          reduce { copy(count = 1) }
+          reduce { copy(count = 2) }
+        }
+
+        verify("only one assert for two reduces") {
+          assertState { copy(count = 1) }
+        }
+      }
+    }
+  }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/RunAnchorTestTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/RunAnchorTestTest.kt
@@ -1,0 +1,99 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+
+private class RunEffect : Effect
+
+private data class RunViewState(
+  val value: Int = 0,
+) : ViewState
+
+private typealias RunAnchor = Anchor<RunEffect, RunViewState, Nothing>
+
+private fun RememberAnchorScope.runAnchor(): RunAnchor =
+  create(
+    initialState = ::RunViewState,
+    effectScope = { RunEffect() },
+  )
+
+class RunAnchorTestTest {
+
+  /**
+   * Verifies that the minimal BDD structure (empty given/on/verify) compiles
+   * and completes without errors. This is the simplest possible test using
+   * the DSL — it exercises the full lifecycle with zero actions and zero
+   * assertions.
+   */
+  @Test
+  fun minimalTestRunsWithoutAssertions() =
+    runAnchorTest(RememberAnchorScope::runAnchor) {
+      given("no setup") {}
+
+      on("doing nothing") {}
+
+      verify("nothing to check") {}
+    }
+
+  /**
+   * Verifies that when no `initialState` is provided in the given block,
+   * the anchor factory's own default state is used. The action reduces
+   * from the factory default (value = 0) to value = 1, confirming the
+   * default was applied.
+   */
+  @Test
+  fun defaultStateFromFactory() =
+    runAnchorTest(RememberAnchorScope::runAnchor) {
+      given("factory defaults") {}
+
+      on("reducing from default state") { reduce { copy(value = value + 1) } }
+
+      verify("state starts from factory default of 0") {
+        assertState { copy(value = value + 1) }
+      }
+    }
+
+  /**
+   * Verifies the simplest happy path: one reduce in the action maps to
+   * exactly one assertState in the verify block. This confirms the basic
+   * wiring between action recording and assertion matching.
+   */
+  @Test
+  fun actionReduceMatchesSingleAssert() =
+    runAnchorTest(RememberAnchorScope::runAnchor) {
+      given("default state") {}
+
+      on("a single reduce") { reduce { copy(value = 42) } }
+
+      verify("one assertState matches") {
+        assertState { copy(value = 42) }
+      }
+    }
+
+  /**
+   * Verifies that multiple reduces in a single action are all recorded
+   * and must each be matched by an assertState call. This tests the
+   * size-equality check in [AnchorTestScope.assertEvents] which ensures
+   * expectedActions.size == actualActions.size.
+   */
+  @Test
+  fun multipleReducesMatchMultipleAsserts() =
+    runAnchorTest(RememberAnchorScope::runAnchor) {
+      given("default state") {}
+
+      on("three sequential reduces") {
+        reduce { copy(value = 1) }
+        reduce { copy(value = 2) }
+        reduce { copy(value = 3) }
+      }
+
+      verify("three assertState calls match in order") {
+        assertState { copy(value = 1) }
+        assertState { copy(value = 2) }
+        assertState { copy(value = 3) }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/SignalTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/SignalTest.kt
@@ -1,0 +1,112 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.Signal
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+private class SigEffect : Effect
+
+private data class SigViewState(
+  val value: Int = 0,
+) : ViewState
+
+private sealed interface SigSignal : Signal {
+  data object Ping : SigSignal
+  data object Pong : SigSignal
+}
+
+private typealias SigAnchor = Anchor<SigEffect, SigViewState, Nothing>
+
+private fun RememberAnchorScope.sigAnchor(): SigAnchor =
+  create(
+    initialState = ::SigViewState,
+    effectScope = { SigEffect() },
+  )
+
+class SignalTest {
+
+  /**
+   * Verifies that a single signal posted via `post { }` is captured by
+   * the test runtime and correctly matched by assertSignal. The signal
+   * is compared by value equality.
+   */
+  @Test
+  fun singleSignalPosted() =
+    runAnchorTest(RememberAnchorScope::sigAnchor) {
+      given("default state") {}
+
+      on("posting a Ping signal") { post { SigSignal.Ping } }
+
+      verify("Ping signal was recorded") {
+        assertSignal { SigSignal.Ping }
+      }
+    }
+
+  /**
+   * Verifies that multiple signals posted in sequence are recorded in
+   * order and must be asserted in the same order. Swapping the order
+   * in verify would fail.
+   */
+  @Test
+  fun multipleSignalsInOrder() =
+    runAnchorTest(RememberAnchorScope::sigAnchor) {
+      given("default state") {}
+
+      on("posting Ping then Pong") {
+        post { SigSignal.Ping }
+        post { SigSignal.Pong }
+      }
+
+      verify("signals match in posted order") {
+        assertSignal { SigSignal.Ping }
+        assertSignal { SigSignal.Pong }
+      }
+    }
+
+  /**
+   * Negative test: verifies that asserting the wrong signal type causes
+   * an AssertionError. The assertEquals in the SignalAction branch of
+   * assertEvents detects the mismatch.
+   */
+  @Test
+  fun signalMismatchFails() {
+    assertFailsWith<AssertionError> {
+      runAnchorTest(RememberAnchorScope::sigAnchor) {
+        given("default state") {}
+
+        on("posting Ping") { post { SigSignal.Ping } }
+
+        verify("wrong signal asserted") {
+          assertSignal { SigSignal.Pong }
+        }
+      }
+    }
+  }
+
+  /**
+   * Verifies that signals can be interleaved with reduces and both are
+   * recorded in the correct order. The assertState/assertSignal/assertState
+   * sequence must exactly match the reduce/post/reduce action sequence.
+   */
+  @Test
+  fun signalInterleavedWithReduce() =
+    runAnchorTest(RememberAnchorScope::sigAnchor) {
+      given("default state") {}
+
+      on("reduce, signal, reduce") {
+        reduce { copy(value = 1) }
+        post { SigSignal.Ping }
+        reduce { copy(value = 2) }
+      }
+
+      verify("actions match in order") {
+        assertState { copy(value = 1) }
+        assertSignal { SigSignal.Ping }
+        assertState { copy(value = 2) }
+      }
+    }
+}

--- a/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/WithStateTest.kt
+++ b/anchor-test/src/commonTest/kotlin/dev/kioba/anchor/test/WithStateTest.kt
@@ -1,0 +1,84 @@
+package dev.kioba.anchor.test
+
+import dev.kioba.anchor.Anchor
+import dev.kioba.anchor.Effect
+import dev.kioba.anchor.RememberAnchorScope
+import dev.kioba.anchor.ViewState
+import kotlin.test.Test
+
+private class WsEffect : Effect
+
+private data class WsViewState(
+  val count: Int = 0,
+  val doubled: Int = 0,
+) : ViewState
+
+private typealias WsAnchor = Anchor<WsEffect, WsViewState, Nothing>
+
+private fun RememberAnchorScope.wsAnchor(): WsAnchor =
+  create(
+    initialState = ::WsViewState,
+    effectScope = { WsEffect() },
+  )
+
+class WithStateTest {
+
+  /**
+   * Verifies that `withState` reads the current state. Given an initial
+   * state with count = 5, `withState { count }` returns 5 which is then
+   * used in a reduce to compute doubled = 10.
+   */
+  @Test
+  fun withStateReadsInitialState() =
+    runAnchorTest(RememberAnchorScope::wsAnchor) {
+      given("initial count of 5") {
+        initialState { WsViewState(count = 5) }
+      }
+
+      on("reading count via withState and doubling it") {
+        val c = withState { count }
+        reduce { copy(doubled = c * 2) }
+      }
+
+      verify("doubled is 10") {
+        assertState { copy(doubled = 10) }
+      }
+    }
+
+  /**
+   * Verifies that `withState` after a reduce reads the updated state.
+   * The first reduce sets count = 10, then `withState { count }` returns
+   * 10, which is stored in doubled via the second reduce.
+   */
+  @Test
+  fun withStateAfterReduceReadsUpdated() =
+    runAnchorTest(RememberAnchorScope::wsAnchor) {
+      given("default state") {}
+
+      on("reduce then withState then reduce") {
+        reduce { copy(count = 10) }
+        val c = withState { count }
+        reduce { copy(doubled = c) }
+      }
+
+      verify("withState saw the updated count") {
+        assertState { copy(count = 10) }
+        assertState { copy(doubled = 10) }
+      }
+    }
+
+  /**
+   * Verifies that `withState` alone does not emit any action. It is a
+   * read-only operation that returns a value derived from the current
+   * state without recording anything in verifyActions.
+   */
+  @Test
+  fun withStateDoesNotEmitAction() =
+    runAnchorTest(RememberAnchorScope::wsAnchor) {
+      given("default state") {}
+
+      on("only withState, no reduce") { withState { count } }
+
+      verify("no actions recorded") {}
+    }
+}

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Anchor.kt
@@ -104,7 +104,6 @@ public interface DefectAnchor<Err> where Err : Any {
    *
    * @param error The domain error to escalate.
    */
-  @AnchorDsl
   public fun orDie(error: Err): Nothing
 }
 
@@ -139,7 +138,6 @@ public interface StateAnchor<S> where S : ViewState {
   /**
    * The current state.
    */
-  @AnchorDsl
   public val state: S
 
   /**
@@ -148,7 +146,6 @@ public interface StateAnchor<S> where S : ViewState {
    * @param block The block to execute.
    * @return The result of the block.
    */
-  @AnchorDsl
   public fun <T> withState(
     block: S.() -> T,
   ): T =
@@ -172,7 +169,6 @@ public interface MutableStateAnchor<S> : StateAnchor<S> where S : ViewState {
    * reduce { copy(count = count + 1) }
    * ```
    */
-  @AnchorDsl
   public fun reduce(
     reducer: S.() -> S,
   )
@@ -197,7 +193,6 @@ public interface EffectAnchor<R> where R : Effect {
    * val result = effect { repository.getData() }
    * ```
    */
-  @AnchorDsl
   public suspend fun <T> effect(
     coroutineContext: CoroutineContext = Dispatchers.IO,
     block: suspend R.() -> T,
@@ -229,7 +224,6 @@ public interface CancellableAnchor<R, S, Err> where R : Effect, S : ViewState, E
    * }
    * ```
    */
-  @AnchorDsl
   public suspend fun cancellable(
     key: Any,
     block: suspend Anchor<R, S, Err>.() -> Unit,
@@ -257,7 +251,6 @@ public interface SubscriptionAnchor {
    * emit { MyEvent.Finished }
    * ```
    */
-  @AnchorDsl
   public suspend fun emit(
     block: SubscriptionScope.() -> Event,
   )
@@ -284,7 +277,6 @@ public interface SignalAnchor {
    * post { CounterSignal.Increment }
    * ```
    */
-  @AnchorDsl
   public suspend fun post(
     block: SignalScope.() -> Signal,
   )

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
@@ -51,7 +51,6 @@ public interface Raise<Err> where Err : Any {
    * val user: User = recover { fetchUser(id) }.getOrRaise()
    * ```
    */
-  @AnchorDsl
   public fun <T> Recover<Err, T>.getOrRaise(): T =
     when (this) {
       is Recover.Ok -> value

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Raise.kt
@@ -22,7 +22,6 @@ public interface Raise<Err> where Err : Any {
    *
    * @param error The domain error to raise.
    */
-  @AnchorDsl
   public fun raise(error: Err): Nothing
 
   /**
@@ -38,7 +37,6 @@ public interface Raise<Err> where Err : Any {
    * @param condition The condition to check.
    * @param error A lazy provider for the domain error to raise when the condition is false.
    */
-  @AnchorDsl
   public fun ensure(condition: Boolean, error: () -> Err) {
     if (!condition) raise(error())
   }

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/Recover.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/Recover.kt
@@ -38,7 +38,6 @@ public sealed interface Recover<out Err, out T> {
  * }
  * ```
  */
-@AnchorDsl
 public suspend inline fun <R, S, Err, T> Anchor<R, S, Err>.recover(
   crossinline block: suspend Anchor<R, S, Err>.() -> T,
 ): Recover<Err, T> where R : Effect, S : ViewState, Err : Any =
@@ -62,7 +61,6 @@ public suspend inline fun <R, S, Err, T> Anchor<R, S, Err>.recover(
  * val result: Recover<MyError, String> = recover { ensure(valid) { MyError }; "ok" }
  * ```
  */
-@AnchorDsl
 public inline fun <Err : Any, T> recover(
   block: Raise<Err>.() -> T,
 ): Recover<Err, T> {

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
@@ -43,7 +43,6 @@ public class SubscriptionsScope<R, S, Err>(
    * @param action The action to execute on the [Anchor].
    * @return The original [Flow].
    */
-  @AnchorDsl
   public fun <I> Flow<I>.anchor(
     action: Anchor<R, S, Err>.(I) -> Unit,
   ): Flow<I> =
@@ -66,7 +65,6 @@ public class SubscriptionsScope<R, S, Err>(
    * }
    * ```
    */
-  @AnchorDsl
   public suspend inline fun <reified A> listen(
     crossinline block: (Flow<A>) -> Flow<*>,
   ) where A : Event {

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ErrorHandling.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/ErrorHandling.kt
@@ -6,8 +6,7 @@ import dev.kioba.anchor.ErrorScope
 import dev.kioba.anchor.RaisedException
 import dev.kioba.anchor.ViewState
 
-@PublishedApi
-internal suspend inline fun <R, S, Err> catchDomainError(
+public suspend inline fun <R, S, Err> catchDomainError(
   anchor: Anchor<R, S, Err>,
   noinline onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)?,
   block: () -> Unit,
@@ -21,8 +20,7 @@ internal suspend inline fun <R, S, Err> catchDomainError(
   }
 }
 
-@PublishedApi
-internal suspend inline fun <R, S, Err> catchDefects(
+public suspend inline fun <R, S, Err> catchDefects(
   anchor: Anchor<R, S, Err>,
   noinline defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)?,
   block: () -> Unit,
@@ -35,8 +33,7 @@ internal suspend inline fun <R, S, Err> catchDefects(
   }
 }
 
-@PublishedApi
-internal suspend inline fun <R, S, Err> safeExecute(
+public suspend inline fun <R, S, Err> safeExecute(
   anchor: Anchor<R, S, Err>,
   noinline onDomainError: (suspend ErrorScope<R, S>.(Err) -> Unit)?,
   noinline defect: (suspend ErrorScope<R, S>.(Throwable) -> Unit)?,

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/StandaloneRecoverTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/StandaloneRecoverTest.kt
@@ -165,7 +165,7 @@ class StandaloneRecoverTest {
     val result: Recover<TestError, String> = recover { validate(-1) }
 
     assertIs<Recover.Error<TestError>>(result)
-    assertIs<TestError.Invalid>((result as Recover.Error).error)
+    assertIs<TestError.Invalid>(result.error)
     Unit
   }
 

--- a/convention-plugins/src/main/kotlin/dev.kioba.kmp-library.gradle.kts
+++ b/convention-plugins/src/main/kotlin/dev.kioba.kmp-library.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 kotlin {
   explicitApi()
 
+  compilerOptions {
+    allWarningsAsErrors.set(true)
+  }
+
   jvm("desktop")
 
   android {


### PR DESCRIPTION
## Summary

Closes #165

Extends the `anchor-test` BDD DSL to support configuring and asserting on domain error handlers (`onDomainError`/`defect`) declaratively in tests.

### New `given {}` methods
- `onDomainError { error -> ... }` — configure domain error handler for the test
- `defect { throwable -> ... }` — configure defect handler for the test
- If not provided, automatically falls back to the handler from the anchor factory's `create()` call

### New `verify {}` assertions
- `assertDomainError { MyError.NotFound }` — assert `onDomainError` was called with the expected error
- `assertNoDomainError()` — assert no domain error occurred
- `assertDefect { DomainDefectException(MyError.Fatal) }` — assert `defect` handler was called with expected throwable

### Handler wiring
- When `raise()` is called during a test action, the resolved `onDomainError` handler is invoked (allowing `reduce {}` calls for state recovery)
- When `orDie()` is called, the resolved `defect` handler is invoked
- Handler assertions are validated after action sequence assertions

### Usage example

```kotlin
runAnchorTest(RememberAnchorScope::myAnchor) {
    given("repository returns not found") {
        effectScope { MyEffect(repository = FailingRepository()) }
        onDomainError { error ->
            reduce { copy(isEmpty = true) }
        }
    }

    on("loading data", MyAnchor::loadData)

    verify("domain error was raised and state updated") {
        assertRaise { DomainError.NotFound }
        assertDomainError { DomainError.NotFound }
        assertState { copy(isEmpty = true) }
    }
}
```

## Files changed

| File | Change |
|------|--------|
| `GivenScope.kt` | Added `Err` type parameter, `onDomainError()`/`defect()` methods |
| `GivenScopeImpl.kt` | Added `Err` type parameter, handler storage and implementation |
| `AnchorTestScope.kt` | Handler wiring in `assert()`, fallback to factory handlers, handler assertion validation |
| `AnchorTestRuntime.kt` | `domainErrors`/`defects` tracking lists |
| `VerifyScope.kt` | `assertDomainError()`/`assertNoDomainError()`/`assertDefect()` |
| `VerifyScopeImpl.kt` | Implementation with separate tracking fields |

## Test plan

- [x] `./gradlew :anchor-test:desktopTest` — compiles successfully
- [x] `./gradlew :features:counter:allTests` — existing tests pass unchanged
- [x] `./gradlew :features:config:allTests` — existing tests pass unchanged
- [x] `./gradlew :features:main:allTests` — existing tests pass unchanged
- [x] `./gradlew allTests` — full suite passes