### PR TITLE
💚 Drop GitHub Packages publish and split build from publish

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
-      packages: write
       pull-requests: write
 
     steps:
@@ -89,18 +88,16 @@ jobs:
           echo "=== gradle.properties ==="
           grep -v -E '^(#|$)' gradle.properties
 
-      - name: Publish to GitHub Packages
+      - name: Assemble publishable artifacts
         if: steps.changes.outputs.has_changes == 'true'
         timeout-minutes: 30
         run: >
-          ./gradlew publishAllPublicationsToGithubPackagesRepository
-          --no-configuration-cache
+          ./gradlew
+          :anchor:assemble
+          :anchor-compose:assemble
+          :anchor-test:assemble
+          :anchor-internal:assemble
           --stacktrace
-        env:
-          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ github.actor }}
-          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
 
       - name: Publish to Maven Central
         if: steps.changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

- Remove the **Publish to GitHub Packages** step. It has been hitting the 30-min timeout because each `publish…ToGithubPackagesRepository` task takes 30–90s of GHP API time and there are ~24 of them across the four published modules, leaving no headroom for the Maven Central step that follows.
- Maven Central is the canonical distribution for this library; GitHub Packages was redundant. Run [#26649644155](https://github.com/kioba/anchor/actions/runs/26649644155) is the latest example — it got partway through `anchor-internal` before the cap, and Maven Central never ran.
- Split build from publish: add an **Assemble publishable artifacts** step that runs `:assemble` on `anchor`, `anchor-compose`, `anchor-test`, and `anchor-internal` before the Maven Central step. Compile failures (e.g. iOS-only deprecations) now surface separately from publish failures, and the publish step reuses Gradle's task cache so it only signs, bundles, and uploads.
- Drop the now-unused `packages: write` permission.

`--no-configuration-cache` stays on the publish step (vanniktech's Central Portal flow is fragile under it). The convention plugin's GHP config is left untouched — cheap to revert if GHP is ever needed again.

## Test plan

- [ ] Manually trigger `publish package` via `workflow_dispatch` on this branch
- [ ] Confirm the Assemble step completes well under 30 min
- [ ] Confirm `publishAndReleaseToMavenCentral` lands `0.1.5` on Central Portal
- [ ] Confirm the `0.1.5` tag is pushed and a "Bump version to 0.1.6" PR is opened