### PR TITLE
🐛 Update version of all anchor-* artifacts in README and AGENTS

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -148,11 +148,11 @@ jobs:
           git checkout -b "$BRANCH"
           sed -i '' "s/^POM_VERSION=.*/POM_VERSION=$NEXT_VERSION/" gradle.properties
           GROUP_ID=$(grep '^POM_GROUP_ID=' gradle.properties | cut -d'=' -f2)
-          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" README.md
+          sed -i '' -E "s|(${GROUP_ID}:anchor[a-z-]*):[0-9]+\.[0-9]+\.[0-9]+|\1:${VERSION}|g" README.md
           sed -i '' "s|version: \"[0-9]*\.[0-9]*\.[0-9]*\"|version: \"${VERSION}\"|" mkdocs.yml
           sed -i '' "s|Published version: \`[0-9]*\.[0-9]*\.[0-9]*\`|Published version: \`${VERSION}\`|g" CLAUDE.md
           bash scripts/generate-llms-full.sh
-          sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" AGENTS.md
+          sed -i '' -E "s|(${GROUP_ID}:anchor[a-z-]*):[0-9]+\.[0-9]+\.[0-9]+|\1:${VERSION}|g" AGENTS.md
           sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" AGENTS.md
           git add gradle.properties README.md mkdocs.yml CLAUDE.md AGENTS.md docs/llms-full.txt
           git commit -m "🔖 Bump version to $NEXT_VERSION"


### PR DESCRIPTION
## Summary

- The "Bump patch version" step in `package-publish.yml` used a sed pattern that only matched the bare `anchor` coordinate. `anchor-compose:` and `anchor-test:` were skipped because the regex required `:` immediately after `anchor`, leaving those dependency snippets in `README.md` / `AGENTS.md` stuck at whatever they were last manually edited to.
- Visible in [PR #233](https://github.com/kioba/anchor/pull/233/files): `anchor` line went `0.1.3 → 0.1.5`, but `anchor-compose` and `anchor-test` stayed at `0.1.0`.
- Switch to an extended-regex pattern with a capture group so all `anchor-*` artifacts get bumped:

```diff
- sed -i '' "s|${GROUP_ID}:anchor:[0-9]*\.[0-9]*\.[0-9]*|${GROUP_ID}:anchor:${VERSION}|g" README.md
+ sed -i '' -E "s|(${GROUP_ID}:anchor[a-z-]*):[0-9]+\.[0-9]+\.[0-9]+|\1:${VERSION}|g" README.md
```

The character class `[a-z-]*` matches `anchor`, `anchor-compose`, `anchor-test`, and any future `anchor-*` artifact (e.g. `anchor-internal`).

`docs/llms-full.txt` was already correct because it's regenerated by `scripts/generate-llms-full.sh`, which sources the artifact list explicitly.

## Test plan

I verified the new pattern locally against the actual snippets in the repo:

```console
$ printf 'implementation("dev.kioba.anchor:anchor:0.1.3")\nimplementation("dev.kioba.anchor:anchor-compose:0.1.0")\ntestImplementation("dev.kioba.anchor:anchor-test:0.1.0")\n' \
    | sed -E "s|(dev\.kioba\.anchor:anchor[a-z-]*):[0-9]+\.[0-9]+\.[0-9]+|\1:9.9.9|g"
implementation("dev.kioba.anchor:anchor:9.9.9")
implementation("dev.kioba.anchor:anchor-compose:9.9.9")
testImplementation("dev.kioba.anchor:anchor-test:9.9.9")
```

- [ ] Once the next publisher runs, confirm the auto-generated "Bump version to X.Y.Z" PR updates all three artifact lines in `README.md` and `AGENTS.md`