### PR TITLE
📝 Sync stale doc versions to 0.1.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Anchor is a state management architecture for Kotlin Multiplatform with Jetpack 
 
 - **Repository**: https://github.com/kioba/anchor
 - **Docs**: https://kioba.github.io/anchor/
-- **Published version**: 0.1.0
+- **Published version**: 0.1.5
 - **Platforms**: Android, iOS (iosX64, iosArm64, iosSimulatorArm64), Desktop (JVM)
 
 ## Modules
@@ -12,8 +12,8 @@ Anchor is a state management architecture for Kotlin Multiplatform with Jetpack 
 ```kotlin
 dependencies {
     implementation("dev.kioba.anchor:anchor:0.1.5")        // Core state management
-    implementation("dev.kioba.anchor:anchor-compose:0.1.0") // Compose bindings
-    testImplementation("dev.kioba.anchor:anchor-test:0.1.0") // Testing DSL
+    implementation("dev.kioba.anchor:anchor-compose:0.1.5") // Compose bindings
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.5") // Testing DSL
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Add the dependencies to your `build.gradle.kts`:
 ```kotlin
 dependencies {
     implementation("dev.kioba.anchor:anchor:0.1.5")
-    implementation("dev.kioba.anchor:anchor-compose:0.1.0")
-    testImplementation("dev.kioba.anchor:anchor-test:0.1.0")
+    implementation("dev.kioba.anchor:anchor-compose:0.1.5")
+    testImplementation("dev.kioba.anchor:anchor-test:0.1.5")
 }
 ```
 


### PR DESCRIPTION
## Summary

Catch up doc fields that the publish workflow's sed substitutions silently missed across previous releases.

- `README.md`, `AGENTS.md`: bump `anchor-compose` and `anchor-test` dependency snippets from `0.1.0` to `0.1.5`. The "Bump patch version" regex only matched the bare `anchor:` coordinate. Fixed forward in #234, but the historically-skipped values were never corrected.
- `AGENTS.md` (line 7): bump `**Published version**` header from `0.1.0` to `0.1.5`.

### Second workflow bug worth fixing in a follow-up

While syncing the doc, I noticed the workflow's "Published version" sed for `AGENTS.md` has the same flavor of bug as the artifact-coordinate one:

```yaml
sed -i '' "s|Published version: [0-9]*\.[0-9]*\.[0-9]*|Published version: ${VERSION}|" AGENTS.md
```

That pattern looks for `Published version: ` (plain), but the file wraps the label in bold (`**Published version**:`), so the colon sits *outside* the label and the regex has never matched. The CLAUDE.md sibling sed (`Published version: \`X.Y.Z\``) does work because that file uses the backtick form the pattern expects.

Happy to send a tiny follow-up PR updating that sed to handle the bold form (or merging it with the CLAUDE.md one).

## Test plan

- [ ] Confirm `anchor-compose` and `anchor-test` snippets read `0.1.5` in both README and AGENTS
- [ ] Confirm `AGENTS.md` line 7 reads `**Published version**: 0.1.5`