### PR TITLE
🐛 Isolate connect() subscriptions with SupervisorJob, rename listen → connect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Subscriptions set up reactive event handling chains:
 
 ```kotlin
 suspend fun MainSubScope.subscriptions() {
-  listen(::refresh)  // Connect event flow to handler
+  connect(::refresh)  // Connect event flow to handler
 }
 
 internal fun MainSubScope.refresh(flow: Flow<MainEvent>): Flow<Int> =

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/SubscriptionDsl.kt
@@ -53,19 +53,19 @@ public class SubscriptionsScope<R, S, Err>(
     }
 
   /**
-   * Listens for internal [Event]s of type [A].
+   * Connects a handler to internal [Event]s of type [A].
    *
-   * @param A The type of [Event] to listen for.
+   * @param A The type of [Event] to connect to.
    * @param block A transformation block that takes a [Flow] of [A] and returns a [Flow] to be collected.
    *
    * Example:
    * ```kotlin
-   * listen<MyEvent.Finished> { events ->
+   * connect<MyEvent.Finished> { events ->
    *   events.onEach { /* do something */ }
    * }
    * ```
    */
-  public suspend inline fun <reified A> listen(
+  public suspend inline fun <reified A> connect(
     crossinline block: (Flow<A>) -> Flow<*>,
   ) where A : Event {
     wrap {

--- a/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
+++ b/anchor/src/commonMain/kotlin/dev/kioba/anchor/internal/AnchorRuntime.kt
@@ -16,6 +16,7 @@ import dev.kioba.anchor.SubscriptionsScope
 import dev.kioba.anchor.ViewState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -27,7 +28,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -90,7 +90,7 @@ internal class AnchorRuntime<R, S, Err>(
     init?.invoke(this@AnchorRuntime)
   }
 
-  private suspend fun <T : Event> SharedFlow<T>.handlers(): Flow<Any?> =
+  private suspend fun <T : Event> SharedFlow<T>.handlers(): List<Flow<*>> =
     SubscriptionsScope<R, S, Err>(
       chain = this,
       anchor = this@AnchorRuntime,
@@ -105,12 +105,18 @@ internal class AnchorRuntime<R, S, Err>(
             throw e
           }
         }
-      }.merge()
+      }
 
-  suspend fun CoroutineScope.subscribe(): Job =
-    emitter
-      .handlers()
-      .launchIn(this)
+  suspend fun CoroutineScope.subscribe(): Job {
+    val handlers = emitter.handlers()
+    // SupervisorJob: a thrown subscription must not cancel siblings.
+    val supervisor = SupervisorJob(parent = this.coroutineContext[Job])
+    val supervised = CoroutineScope(this.coroutineContext + supervisor)
+    for (flow in handlers) {
+      flow.launchIn(supervised)
+    }
+    return supervisor
+  }
 
   // DSL
 

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/SubscriptionDslTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/SubscriptionDslTest.kt
@@ -1,11 +1,27 @@
 package dev.kioba.anchor
 
 import dev.kioba.anchor.internal.AnchorRuntime
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private sealed interface SubTestEvent : Event {
+  data class Crash(val value: Int) : SubTestEvent
+
+  data class Survive(val value: Int) : SubTestEvent
+}
 
 class SubscriptionDslTest {
 
@@ -52,5 +68,58 @@ class SubscriptionDslTest {
       }
 
       assertEquals(99, anchor.state.value)
+    }
+
+  @Test
+  fun `sibling subscription keeps receiving events when another subscription throws`(): Unit =
+    runBlocking {
+      val survivedValues = mutableListOf<Int>()
+      val anchor =
+        AnchorRuntime<EmptyEffect, TestState, TestError>(
+          initialState = { TestState(value = 0) },
+          effectScope = { EmptyEffect },
+          subscriptions = {
+            listen<SubTestEvent.Crash> { events ->
+              events.map<SubTestEvent.Crash, Unit> { event ->
+                throw IllegalStateException("subscription boom: ${event.value}")
+              }
+            }
+            listen<SubTestEvent.Survive> { events ->
+              events.onEach { event -> survivedValues.add(event.value) }
+            }
+          },
+        )
+
+      coroutineScope {
+        val supervisorReady = CompletableDeferred<Job>()
+        launch {
+          with(anchor) {
+            supervisorReady.complete(subscribe())
+          }
+        }
+        val supervisor = supervisorReady.await()
+
+        // Wait for both listen() flows to start collecting from _emitter.
+        withTimeout(2_000) {
+          while (anchor._emitter.subscriptionCount.value < 2) yield()
+        }
+
+        // Trigger the crashing subscription. Before the supervisor isolation
+        // fix, this also tears down the surviving subscription.
+        anchor._emitter.emit(SubTestEvent.Crash(value = 1))
+
+        // The surviving subscription must still receive new events.
+        anchor._emitter.emit(SubTestEvent.Survive(value = 7))
+        anchor._emitter.emit(SubTestEvent.Survive(value = 11))
+
+        withTimeout(2_000) {
+          while (survivedValues.size < 2) yield()
+        }
+
+        assertEquals(listOf(7, 11), survivedValues)
+        assertTrue(supervisor.isActive, "supervisor must stay active when a child throws")
+
+        supervisor.cancelAndJoin()
+      }
     }
 }

--- a/anchor/src/commonTest/kotlin/dev/kioba/anchor/SubscriptionDslTest.kt
+++ b/anchor/src/commonTest/kotlin/dev/kioba/anchor/SubscriptionDslTest.kt
@@ -79,12 +79,12 @@ class SubscriptionDslTest {
           initialState = { TestState(value = 0) },
           effectScope = { EmptyEffect },
           subscriptions = {
-            listen<SubTestEvent.Crash> { events ->
+            connect<SubTestEvent.Crash> { events ->
               events.map<SubTestEvent.Crash, Unit> { event ->
                 throw IllegalStateException("subscription boom: ${event.value}")
               }
             }
-            listen<SubTestEvent.Survive> { events ->
+            connect<SubTestEvent.Survive> { events ->
               events.onEach { event -> survivedValues.add(event.value) }
             }
           },
@@ -99,7 +99,7 @@ class SubscriptionDslTest {
         }
         val supervisor = supervisorReady.await()
 
-        // Wait for both listen() flows to start collecting from _emitter.
+        // Wait for both connect() flows to start collecting from _emitter.
         withTimeout(2_000) {
           while (anchor._emitter.subscriptionCount.value < 2) yield()
         }

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -89,7 +89,7 @@ HandleSignal<MySignal.ShowError> { signal ->
 
 ```kotlin
 subscriptions = {
-    listen<Created> { events ->
+    connect<Created> { events ->
         events.anchor { loadData() }
     }
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -191,7 +191,7 @@ HandleSignal<MySignal.ShowError> { signal ->
 
 ```kotlin
 subscriptions = {
-    listen<Created> { events ->
+    connect<Created> { events ->
         events.anchor { loadData() }
     }
 }

--- a/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainSubscriptions.kt
+++ b/features/main/src/commonMain/kotlin/dev/kioba/anchor/features/main/data/MainSubscriptions.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onEach
 
 internal suspend fun MainSubScope.subscriptions() {
-  listen(::refresh)
+  connect(::refresh)
 }
 
 internal fun MainEffect.helloListening(): Flow<Int> =


### PR DESCRIPTION
Closes #182

## Summary

- **Isolation fix**: a single subscription throwing used to tear down the merged flow shared by every subscription on the same anchor, killing siblings (e.g. an auth listener dying when a Firestore listener throws). Each subscription flow now runs under a `SupervisorJob` whose parent is the calling scope's job, so per-subscription failures stay isolated. Parent-scope cancellation (ViewModel clear) still cancels every subscription. `subscribe()` still returns a single `Job` (the supervisor) so callers can `cancelAndJoin()` it; existing `.catch`/`safeExecute` routing through `onDomainError`/`defect` is preserved.
- **Rename**: `SubscriptionsScope.listen<A> { ... }` → `connect<A> { ... }`. The DSL wires an event flow to a handler — `connect` better matches what call sites do (the inline comment in `CLAUDE.md` already read "Connect event flow to handler"). Touched the function + KDoc, the call site in `features/main`, the new regression test, and the snippets in `docs/concepts.md`, `docs/llms-full.txt`, and `CLAUDE.md`.

> ⚠️ Source-breaking for consumers of `SubscriptionsScope.listen` — a one-line find/replace `listen<` → `connect<` and `listen(::` → `connect(::` is the full migration.

## Test plan

- Added `SubscriptionDslTest.\`sibling subscription keeps receiving events when another subscription throws\`` — wires two `connect()` subscriptions, lets the first throw on its first event, and verifies the second one continues to receive subsequent events (and the supervisor stays active).
- Confirmed the new test fails without the runtime change (`Caused by: java.lang.IllegalStateException`) and passes with it.
- `./gradlew :anchor:desktopTest` — 90 tests, 0 failures.
- `./gradlew :features:main:compileCommonMainKotlinMetadata` to confirm the rename's downstream call site compiles.