### PR TITLE
✨ Add NavigationSignal base interface

### DIFF
--- a/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/NavigationSignal.kt
+++ b/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/NavigationSignal.kt
@@ -1,0 +1,36 @@
+package dev.kioba.anchor.compose
+
+import dev.kioba.anchor.Signal
+
+/**
+ * Opt-in convention for common navigation [Signal]s emitted from an Anchor.
+ *
+ * Provides ready-made variants for "navigate back" and "navigate back with a result",
+ * without coupling Anchor to any specific navigation framework. The type parameter on
+ * [BackWith] is named `T` rather than `R` to avoid collision with the conventional
+ * `R : Effect` type parameter used throughout the Anchor DSL.
+ *
+ * @sample
+ * ```kotlin
+ * suspend fun DetailsAnchor.close() {
+ *   post { NavigationSignal.Back }
+ * }
+ *
+ * suspend fun DetailsAnchor.submit(id: Long) {
+ *   post { NavigationSignal.BackWith(id) }
+ * }
+ * ```
+ */
+public interface NavigationSignal : Signal {
+  /**
+   * Signal requesting a plain "navigate back" with no payload.
+   */
+  public data object Back : NavigationSignal
+
+  /**
+   * Signal requesting a "navigate back" carrying a [result] for the previous destination.
+   *
+   * @param result The value to deliver back to the previous destination.
+   */
+  public data class BackWith<T>(public val result: T) : NavigationSignal
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in `NavigationSignal` base interface in `anchor-compose` with `Back` and `BackWith<T>` variants for the most common navigation intents.
- Pure convention only — no dependency on any navigation framework, and the core `anchor` module remains untouched.

The `BackWith` payload type parameter is named `T` instead of `R` to avoid visual collision with the conventional `R : Effect` parameter used across the Anchor DSL.

Closes #169.

## Test plan

- [x] `./gradlew :anchor-compose:compileCommonMainKotlinMetadata :anchor-compose:desktopTest` passes locally.
- [ ] CI green on the PR.