### PR TITLE
✨ Add AnchorConsumer composable

### DIFF
--- a/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/AnchorConsumer.kt
+++ b/anchor-compose/src/commonMain/kotlin/dev/kioba/anchor/compose/AnchorConsumer.kt
@@ -1,0 +1,44 @@
+package dev.kioba.anchor.compose
+
+import androidx.compose.runtime.Composable
+import dev.kioba.anchor.AnchorScope
+
+/**
+ * Exposes the current [AnchorScope] to non-composable callbacks.
+ *
+ * Use this when you need to invoke an Anchor action from a context that cannot directly
+ * call the [anchor] composable, such as the `onClick` body of an `AndroidView` or other
+ * interop layers that take plain Kotlin callbacks.
+ *
+ * @param content Receives the [AnchorScope] provided by the nearest [RememberAnchor]
+ *        in the composition tree.
+ *
+ * @sample
+ * ```kotlin
+ * @Composable
+ * fun CounterScreen() {
+ *   RememberAnchor(scope = { counterAnchor() }) { state ->
+ *     AnchorConsumer { scope ->
+ *       AndroidView(
+ *         factory = { context ->
+ *           Button(context).apply {
+ *             setOnClickListener {
+ *               scope.execute { (this as CounterAnchor).increment() }
+ *             }
+ *           }
+ *         },
+ *       )
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @see anchor For the preferred way to create action callbacks in pure Compose code
+ * @see RememberAnchor For providing the AnchorScope
+ */
+@Composable
+public fun AnchorConsumer(
+  content: @Composable (AnchorScope<*, *>) -> Unit,
+) {
+  content(LocalAnchor.current)
+}


### PR DESCRIPTION
## Summary

- Adds `AnchorConsumer` composable in `anchor-compose` that exposes the current `AnchorScope` to non-composable callbacks (e.g. an `AndroidView` `onClick` body).
- Thin wrapper around `LocalAnchor.current` so interop layers that take plain Kotlin callbacks can still drive Anchor actions.

Closes #168

## Test plan

- [x] `./gradlew :anchor-compose:compileCommonMainKotlinMetadata :anchor-compose:desktopTest` — BUILD SUCCESSFUL.
- [ ] Manually verify usage from an `AndroidView` interop site in a downstream consumer.